### PR TITLE
feat(pipeline): implement preview.py script

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,15 +18,15 @@ class PreviewPreset:
 PREVIEW_PRESETS: dict[str, PreviewPreset] = {
     "small_video": PreviewPreset(
         name="small_video",
-        resolution=(640, 360),
-        video_bitrate=500_000,
-        audio_bitrate=64_000,
-    ),
-    "big_video": PreviewPreset(
-        name="big_video",
         resolution=(320, 180),
         video_bitrate=150_000,
         audio_bitrate=32_000,
+    ),
+    "big_video": PreviewPreset(
+        name="big_video",
+        resolution=(640, 360),
+        video_bitrate=500_000,
+        audio_bitrate=64_000,
     ),
 }
 

--- a/app/config.py
+++ b/app/config.py
@@ -16,14 +16,14 @@ class PreviewPreset:
 
 
 PREVIEW_PRESETS: dict[str, PreviewPreset] = {
-    "standard": PreviewPreset(
-        name="standard",
+    "small_video": PreviewPreset(
+        name="small_video",
         resolution=(640, 360),
         video_bitrate=500_000,
         audio_bitrate=64_000,
     ),
-    "long_session": PreviewPreset(
-        name="long_session",
+    "big_video": PreviewPreset(
+        name="big_video",
         resolution=(320, 180),
         video_bitrate=150_000,
         audio_bitrate=32_000,

--- a/app/config.py
+++ b/app/config.py
@@ -1,8 +1,34 @@
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings
+
+
+@dataclass(frozen=True)
+class PreviewPreset:
+    name: str
+    resolution: tuple[int, int]
+    video_bitrate: int
+    audio_bitrate: int = 64_000
+    crf: int | None = None
+
+
+PREVIEW_PRESETS: dict[str, PreviewPreset] = {
+    "standard": PreviewPreset(
+        name="standard",
+        resolution=(640, 360),
+        video_bitrate=500_000,
+        audio_bitrate=64_000,
+    ),
+    "long_session": PreviewPreset(
+        name="long_session",
+        resolution=(320, 180),
+        video_bitrate=150_000,
+        audio_bitrate=32_000,
+    ),
+}
 
 
 class Settings(BaseSettings):
@@ -17,6 +43,7 @@ class Settings(BaseSettings):
     data_dir: str = "data"
     storage_backend: Literal["local"] = "local"
     ingest_roots: list[Path] = []
+    preview_presets: dict[str, PreviewPreset] = PREVIEW_PRESETS
 
     @field_validator("ingest_roots", mode="after")
     @classmethod

--- a/app/pipeline/preview.py
+++ b/app/pipeline/preview.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import av
+
+from app.config import PreviewPreset
+
+
+def generate_preview(
+    input_path: Path,
+    output_path: Path,
+    preset: PreviewPreset,
+) -> None:
+    """
+    Generate a low-resolution review clip from an input recording using PyAV.
+
+    Applies the target resolution, video bitrate (or CRF), and audio bitrate
+    specified by the given PreviewPreset.
+    """
+    container_options = (
+        {"movflags": "faststart"} if output_path.suffix.lower() == ".mp4" else {}
+    )
+    with (
+        av.open(str(input_path)) as in_container,
+        av.open(str(output_path), mode="w", options=container_options) as out_container,
+    ):
+        in_video = in_container.streams.video[0] if in_container.streams.video else None
+        in_audio = in_container.streams.audio[0] if in_container.streams.audio else None
+
+        if not in_video and not in_audio:
+            raise ValueError(f"No video or audio streams found in {input_path}")
+
+        out_video = None
+        out_audio = None
+        width, height = preset.resolution
+
+        if in_video:
+            fps = in_video.guessed_rate or in_video.average_rate or 24
+            options = {"crf": str(preset.crf)} if preset.crf is not None else {}
+            out_video = out_container.add_stream("libx264", rate=fps, options=options)
+            out_video.width = width
+            out_video.height = height
+            out_video.pix_fmt = "yuv420p"
+            if preset.crf is None:
+                out_video.bit_rate = preset.video_bitrate
+
+        if in_audio:
+            out_audio = out_container.add_stream("aac", rate=in_audio.rate or 44100)
+            out_audio.bit_rate = preset.audio_bitrate
+            out_audio.layout = in_audio.layout.name if in_audio.layout else "mono"
+
+        streams = [s for s in (in_video, in_audio) if s is not None]
+        for packet in in_container.demux(*streams):
+            for frame in packet.decode():
+                if packet.stream.type == "video" and out_video:
+                    reformatted = frame.reformat(
+                        width=width, height=height, format="yuv420p"
+                    )
+                    for out_pkt in out_video.encode(reformatted):
+                        out_container.mux(out_pkt)
+                elif packet.stream.type == "audio" and out_audio:
+                    for out_pkt in out_audio.encode(frame):
+                        out_container.mux(out_pkt)
+
+        if out_video:
+            for out_pkt in out_video.encode():
+                out_container.mux(out_pkt)
+
+        if out_audio:
+            for out_pkt in out_audio.encode():
+                out_container.mux(out_pkt)

--- a/tests/pipeline/__init__.py
+++ b/tests/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pipeline modules."""

--- a/tests/pipeline/test_preview.py
+++ b/tests/pipeline/test_preview.py
@@ -16,8 +16,8 @@ from tests.conftest import (
 )
 
 
-def test_generate_preview_standard_preset(tmp_path: Path):
-    """Verify preview generation with the standard preset on video+audio clip."""
+def test_generate_preview_small_video_preset(tmp_path: Path):
+    """Verify preview generation with the small_video preset on video+audio clip."""
     # Create higher-resolution synthetic source (720p) with video and audio
     input_clip = generate_clip(
         2.0,
@@ -25,9 +25,9 @@ def test_generate_preview_standard_preset(tmp_path: Path):
         pattern="gradient",
         output_dir=tmp_path,
     )
-    output_clip = tmp_path / "standard_preview.mp4"
+    output_clip = tmp_path / "small_video_preview.mp4"
 
-    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["standard"])
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["small_video"])
 
     assert output_clip.is_file()
     assert_playable(output_clip)
@@ -42,13 +42,13 @@ def test_generate_preview_standard_preset(tmp_path: Path):
     assert output_clip.stat().st_size < input_clip.stat().st_size
 
 
-def test_generate_preview_long_session_preset(tmp_path: Path):
+def test_generate_preview_big_video_preset(tmp_path: Path):
     """
-    Verify preview generation with the long_session preset.
+    Verify preview generation with the big_video preset (lower bitrate/resolution for long recordings).
 
     Note on simulating a long session:
     Since real 60-minute fixtures are impractical for unit tests, a short synthetic clip
-    is used to exercise the 'long_session' preset directly. The preset's encoding and
+    is used to exercise the 'big_video' preset directly. The preset's encoding and
     compression behavior is what is under test, not the literal wall-clock duration.
     """
     input_clip = generate_clip(
@@ -57,9 +57,9 @@ def test_generate_preview_long_session_preset(tmp_path: Path):
         pattern="gradient",
         output_dir=tmp_path,
     )
-    output_clip = tmp_path / "long_session_preview.mp4"
+    output_clip = tmp_path / "big_video_preview.mp4"
 
-    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["long_session"])
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["big_video"])
 
     assert output_clip.is_file()
     assert_playable(output_clip)
@@ -74,7 +74,7 @@ def test_generate_preview_long_session_preset(tmp_path: Path):
 
 def test_presets_are_differentiated(tmp_path: Path):
     """
-    Verify that standard and long_session presets produce measurably different output
+    Verify that small_video and big_video presets produce measurably different output
     (resolution and file size/bitrate) on the exact same input clip.
     """
     input_clip = generate_clip(
@@ -83,20 +83,20 @@ def test_presets_are_differentiated(tmp_path: Path):
         pattern="gradient",
         output_dir=tmp_path,
     )
-    std_output = tmp_path / "diff_std.mp4"
-    long_output = tmp_path / "diff_long.mp4"
+    small_output = tmp_path / "diff_small.mp4"
+    big_output = tmp_path / "diff_big.mp4"
 
-    generate_preview(input_clip, std_output, PREVIEW_PRESETS["standard"])
-    generate_preview(input_clip, long_output, PREVIEW_PRESETS["long_session"])
+    generate_preview(input_clip, small_output, PREVIEW_PRESETS["small_video"])
+    generate_preview(input_clip, big_output, PREVIEW_PRESETS["big_video"])
 
-    std_info = open_and_inspect(std_output)
-    long_info = open_and_inspect(long_output)
+    small_info = open_and_inspect(small_output)
+    big_info = open_and_inspect(big_output)
 
-    assert std_info.resolution == (640, 360)
-    assert long_info.resolution == (320, 180)
+    assert small_info.resolution == (640, 360)
+    assert big_info.resolution == (320, 180)
 
-    # long_session preset must produce a smaller file size than standard preset
-    assert long_output.stat().st_size < std_output.stat().st_size
+    # big_video preset (for long sessions) must produce a smaller file size than small_video preset
+    assert big_output.stat().st_size < small_output.stat().st_size
 
 
 def test_generate_preview_video_only(tmp_path: Path):
@@ -111,7 +111,7 @@ def test_generate_preview_video_only(tmp_path: Path):
     )
     output_clip = tmp_path / "video_only_preview.mp4"
 
-    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["standard"])
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["small_video"])
 
     assert output_clip.is_file()
     assert_playable(output_clip)
@@ -129,7 +129,7 @@ def test_generate_preview_rejects_corrupt_input(tmp_path: Path):
     output_clip = tmp_path / "corrupt_output.mp4"
 
     with pytest.raises(av.FFmpegError):
-        generate_preview(corrupt_clip, output_clip, PREVIEW_PRESETS["standard"])
+        generate_preview(corrupt_clip, output_clip, PREVIEW_PRESETS["small_video"])
 
 
 def test_generate_preview_custom_preset(tmp_path: Path):

--- a/tests/pipeline/test_preview.py
+++ b/tests/pipeline/test_preview.py
@@ -1,0 +1,156 @@
+"""Unit tests for the pure preview video generator (pipeline/preview.py)."""
+
+from pathlib import Path
+
+import av
+import pytest
+
+from app.config import PREVIEW_PRESETS, PreviewPreset
+from app.pipeline.preview import generate_preview
+from tests.conftest import (
+    assert_duration_close,
+    assert_playable,
+    generate_clip,
+    generate_corrupt_clip,
+    open_and_inspect,
+)
+
+
+def test_generate_preview_standard_preset(tmp_path: Path):
+    """Verify preview generation with the standard preset on video+audio clip."""
+    # Create higher-resolution synthetic source (720p) with video and audio
+    input_clip = generate_clip(
+        2.0,
+        resolution=(1280, 720),
+        pattern="gradient",
+        output_dir=tmp_path,
+    )
+    output_clip = tmp_path / "standard_preview.mp4"
+
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["standard"])
+
+    assert output_clip.is_file()
+    assert_playable(output_clip)
+    assert_duration_close(input_clip, output_clip, tolerance_seconds=0.25)
+
+    info = open_and_inspect(output_clip)
+    assert info.resolution == (640, 360)
+    assert info.has_video
+    assert info.has_audio
+
+    # Preview output must be meaningfully smaller than the uncompressed/higher-res cut input
+    assert output_clip.stat().st_size < input_clip.stat().st_size
+
+
+def test_generate_preview_long_session_preset(tmp_path: Path):
+    """
+    Verify preview generation with the long_session preset.
+
+    Note on simulating a long session:
+    Since real 60-minute fixtures are impractical for unit tests, a short synthetic clip
+    is used to exercise the 'long_session' preset directly. The preset's encoding and
+    compression behavior is what is under test, not the literal wall-clock duration.
+    """
+    input_clip = generate_clip(
+        2.0,
+        resolution=(1280, 720),
+        pattern="gradient",
+        output_dir=tmp_path,
+    )
+    output_clip = tmp_path / "long_session_preview.mp4"
+
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["long_session"])
+
+    assert output_clip.is_file()
+    assert_playable(output_clip)
+    assert_duration_close(input_clip, output_clip, tolerance_seconds=0.25)
+
+    info = open_and_inspect(output_clip)
+    assert info.resolution == (320, 180)
+    assert info.has_video
+    assert info.has_audio
+    assert output_clip.stat().st_size < input_clip.stat().st_size
+
+
+def test_presets_are_differentiated(tmp_path: Path):
+    """
+    Verify that standard and long_session presets produce measurably different output
+    (resolution and file size/bitrate) on the exact same input clip.
+    """
+    input_clip = generate_clip(
+        3.0,
+        resolution=(1280, 720),
+        pattern="gradient",
+        output_dir=tmp_path,
+    )
+    std_output = tmp_path / "diff_std.mp4"
+    long_output = tmp_path / "diff_long.mp4"
+
+    generate_preview(input_clip, std_output, PREVIEW_PRESETS["standard"])
+    generate_preview(input_clip, long_output, PREVIEW_PRESETS["long_session"])
+
+    std_info = open_and_inspect(std_output)
+    long_info = open_and_inspect(long_output)
+
+    assert std_info.resolution == (640, 360)
+    assert long_info.resolution == (320, 180)
+
+    # long_session preset must produce a smaller file size than standard preset
+    assert long_output.stat().st_size < std_output.stat().st_size
+
+
+def test_generate_preview_video_only(tmp_path: Path):
+    """Verify preview generation for clips with video only (no audio stream)."""
+    input_clip = generate_clip(
+        1.0,
+        has_video=True,
+        has_audio=False,
+        resolution=(640, 480),
+        pattern="solid",
+        output_dir=tmp_path,
+    )
+    output_clip = tmp_path / "video_only_preview.mp4"
+
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["standard"])
+
+    assert output_clip.is_file()
+    assert_playable(output_clip)
+    assert_duration_close(input_clip, output_clip, tolerance_seconds=0.25)
+
+    info = open_and_inspect(output_clip)
+    assert info.has_video
+    assert not info.has_audio
+    assert info.resolution == (640, 360)
+
+
+def test_generate_preview_rejects_corrupt_input(tmp_path: Path):
+    """Verify that corrupt or invalid media files raise appropriate errors."""
+    corrupt_clip = generate_corrupt_clip(output_dir=tmp_path)
+    output_clip = tmp_path / "corrupt_output.mp4"
+
+    with pytest.raises(av.FFmpegError):
+        generate_preview(corrupt_clip, output_clip, PREVIEW_PRESETS["standard"])
+
+
+def test_generate_preview_custom_preset(tmp_path: Path):
+    """Verify generate_preview works with a custom PreviewPreset configuration."""
+    custom_preset = PreviewPreset(
+        name="custom_low",
+        resolution=(160, 120),
+        video_bitrate=80_000,
+        audio_bitrate=24_000,
+    )
+    input_clip = generate_clip(
+        1.0,
+        resolution=(320, 240),
+        pattern="gradient",
+        output_dir=tmp_path,
+    )
+    output_clip = tmp_path / "custom_preview.mp4"
+
+    generate_preview(input_clip, output_clip, custom_preset)
+
+    assert output_clip.is_file()
+    assert_playable(output_clip)
+    info = open_and_inspect(output_clip)
+    assert info.resolution == (160, 120)

--- a/tests/pipeline/test_preview.py
+++ b/tests/pipeline/test_preview.py
@@ -34,7 +34,7 @@ def test_generate_preview_small_video_preset(tmp_path: Path):
     assert_duration_close(input_clip, output_clip, tolerance_seconds=0.25)
 
     info = open_and_inspect(output_clip)
-    assert info.resolution == (640, 360)
+    assert info.resolution == (320, 180)
     assert info.has_video
     assert info.has_audio
 
@@ -43,14 +43,7 @@ def test_generate_preview_small_video_preset(tmp_path: Path):
 
 
 def test_generate_preview_big_video_preset(tmp_path: Path):
-    """
-    Verify preview generation with the big_video preset (lower bitrate/resolution for long recordings).
-
-    Note on simulating a long session:
-    Since real 60-minute fixtures are impractical for unit tests, a short synthetic clip
-    is used to exercise the 'big_video' preset directly. The preset's encoding and
-    compression behavior is what is under test, not the literal wall-clock duration.
-    """
+    """Verify preview generation with the big_video preset."""
     input_clip = generate_clip(
         2.0,
         resolution=(1280, 720),
@@ -66,7 +59,7 @@ def test_generate_preview_big_video_preset(tmp_path: Path):
     assert_duration_close(input_clip, output_clip, tolerance_seconds=0.25)
 
     info = open_and_inspect(output_clip)
-    assert info.resolution == (320, 180)
+    assert info.resolution == (640, 360)
     assert info.has_video
     assert info.has_audio
     assert output_clip.stat().st_size < input_clip.stat().st_size
@@ -92,11 +85,11 @@ def test_presets_are_differentiated(tmp_path: Path):
     small_info = open_and_inspect(small_output)
     big_info = open_and_inspect(big_output)
 
-    assert small_info.resolution == (640, 360)
-    assert big_info.resolution == (320, 180)
+    assert small_info.resolution == (320, 180)
+    assert big_info.resolution == (640, 360)
 
-    # big_video preset (for long sessions) must produce a smaller file size than small_video preset
-    assert big_output.stat().st_size < small_output.stat().st_size
+    # small_video preset must produce a smaller file size than big_video preset
+    assert small_output.stat().st_size < big_output.stat().st_size
 
 
 def test_generate_preview_video_only(tmp_path: Path):
@@ -111,7 +104,7 @@ def test_generate_preview_video_only(tmp_path: Path):
     )
     output_clip = tmp_path / "video_only_preview.mp4"
 
-    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["small_video"])
+    generate_preview(input_clip, output_clip, PREVIEW_PRESETS["big_video"])
 
     assert output_clip.is_file()
     assert_playable(output_clip)


### PR DESCRIPTION
# Closes #152 
Implements the pure preview generation module (`app/pipeline/preview.py`) and configurable preview presets in `app/config.py`. 

During the `preview` review gate, loading raw 1080p 60+ minute conference recordings in the browser creates high storage costs and slow review load times. This module generates low-resolution, low-bitrate MP4 previews using PyAV and introduces two configurable presets:
- **`standard`**: `640x360` @ 500 kbps video, 64 kbps AAC audio for standard duration talks.
- **`long_session`**: `320x180` @ 150 kbps video, 32 kbps AAC audio for 60+ minute recordings to keep preview files lightweight and fast to load.

## Key Changes
- **Preset Configuration ([`app/config.py`](file:///Users/virus/Developer/fossasia-new/veditor/app/config.py))**: Added `PreviewPreset` dataclass, defined `standard` and `long_session` in `PREVIEW_PRESETS`, and exposed them via `Settings.preview_presets`.
- **Pure Pipeline Generator ([`app/pipeline/preview.py`](file:///Users/virus/Developer/fossasia-new/veditor/app/pipeline/preview.py))**:
  - Implemented `generate_preview(input_path: Path, output_path: Path, preset: PreviewPreset) -> None`.
  - Transcodes video frames with `libx264` (`yuv420p`) and audio with `aac`.
  - Added `movflags: faststart` to output MP4 containers for instant browser streaming.
  - Adheres to architectural boundaries with zero imports from FastAPI, RQ, SQLAlchemy, or DB layers.
- **Unit Tests ([`tests/pipeline/test_preview.py`](file:///Users/virus/Developer/fossasia-new/veditor/tests/pipeline/test_preview.py))**:
  - Tests `standard` and `long_session` preset generation.
  - Asserts preset differentiation (proves `long_session` produces lower bitrate and smaller size than `standard` on identical input).
  - Verifies duration preservation within tolerance and playable stream decodability.
  - Tests video-only streams, corrupt input rejection, and custom presets.

---

## Automated Test Commands

Run the new preview pipeline tests:
```bash
uv run pytest tests/pipeline/test_preview.py -v
```

Run the architecture and storage boundary guard tests:
```bash
uv run pytest tests/test_pipeline_imports.py tests/test_storage_boundary.py -v
```

Run the complete test suite and linters:
```bash
uv run pytest
```

---

## Manual Test Command

To visually test the preview generator on an actual video file:

```bash
uv run python -c '
from pathlib import Path
from app.config import PREVIEW_PRESETS
from app.pipeline.preview import generate_preview

input_file = Path("path/to/your/recording.mp4")

generate_preview(input_file, Path("preview_small.mp4"), PREVIEW_PRESETS["small_video"])
generate_preview(input_file, Path("preview_big.mp4"), PREVIEW_PRESETS["big_video"])

print("Previews created successfully!")
'
```

Inspect the generated outputs: Compare file sizes of all three files

## Summary by Sourcery

Implement configurable low-bandwidth preview generation for recording review workflows.

New Features:
- Add configurable preview presets for standard and long-session recordings.
- Provide a pure PyAV-based generator for low-resolution MP4 previews with optional audio and browser-friendly streaming output.

Enhancements:
- Support custom preview configurations, video-only inputs, and validation of inputs without media streams.

Tests:
- Add coverage for preset-specific output, compression differences, duration preservation, stream playability, custom presets, video-only media, and corrupt inputs.

## Summary by Sourcery

Implement configurable low-bandwidth preview generation for recording review workflows.

New Features:
- Add configurable small and large preview presets for low-bandwidth recording review.
- Provide a pure PyAV-based generator for browser-friendly, low-resolution MP4 previews with optional audio and custom preset support.

Enhancements:
- Support video-only media and reject inputs without usable media streams.

Tests:
- Add coverage for preset output properties, compression differences, duration preservation, playback, video-only inputs, corrupt media, and custom configurations.