### PR TITLE
feat: rq worker startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN uv venv && uv sync --no-dev --no-install-project
 # Copy application files
 COPY app/ app/
 COPY migrations/ migrations/
+COPY scripts/ scripts/
 COPY alembic.ini .
 
 # Expose the API port

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you prefer to run the entire stack locally without Docker (for faster reloadi
 
 7. Start the RQ worker natively (in a separate terminal):
    ```bash
-   uv run rq worker -u redis://localhost:6379/0 light heavy
+   uv run python scripts/run_worker.py light heavy
    ```
 
 8. Run the tests natively:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,5 @@
+"""Background tasks and RQ job functions for VEditor pipeline.
+
+This module houses stage wrapper functions dispatched via RQ.
+Worker processes eagerly import this module at boot to avoid per-job import overhead.
+"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   worker-light:
     build: .
-    command: uv run rq worker --url redis://redis:6379/0 light
+    command: uv run python scripts/run_worker.py light
     environment:
       - POSTGRES_USER=veditor
       - POSTGRES_PASSWORD=password
@@ -34,7 +34,7 @@ services:
 
   worker-heavy:
     build: .
-    command: uv run rq worker --url redis://redis:6379/0 heavy
+    command: uv run python scripts/run_worker.py heavy
     environment:
       - POSTGRES_USER=veditor
       - POSTGRES_PASSWORD=password

--- a/scripts/run_worker.py
+++ b/scripts/run_worker.py
@@ -1,0 +1,65 @@
+"""RQ Worker entrypoint for VEditor.
+
+Starts an RQ worker process listening on the specified queue(s), reading
+Redis configuration from app.config.settings and eagerly importing task modules.
+"""
+
+import argparse
+import sys
+
+import redis
+import redis.exceptions
+from rq import Worker
+
+# Eagerly import task modules so job code is loaded once at worker boot
+# rather than re-imported per job fork (RQ performance recommendation).
+import app.tasks  # noqa: F401
+from app.config import settings
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run an RQ worker for VEditor.",
+    )
+    parser.add_argument(
+        "queues",
+        nargs="*",
+        default=["light", "heavy"],
+        help="Queue names to listen on (default: light heavy)",
+    )
+    parser.add_argument(
+        "--burst",
+        action="store_true",
+        help="Run in burst mode (quit after all current jobs are processed)",
+    )
+    parser.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help="Custom worker name",
+    )
+
+    args = parser.parse_args(argv)
+
+    queues = args.queues if args.queues else ["light", "heavy"]
+
+    if not settings.redis_url or not settings.redis_url.strip():
+        print("Error: REDIS_URL is unset.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        redis_conn = redis.from_url(settings.redis_url)
+        redis_conn.ping()
+    except (redis.exceptions.RedisError, ValueError) as exc:
+        print(
+            f"Error: Could not connect to Redis at {settings.redis_url}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    worker = Worker(queues, connection=redis_conn, name=args.name)
+    worker.work(burst=args.burst)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,126 @@
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import redis.exceptions
+
+from scripts.run_worker import main
+
+
+def test_eager_import_tasks_rationale():
+    """Verify that scripts/run_worker.py statically imports app.tasks
+
+    for boot-time preloading.
+    """
+    script_path = Path(__file__).parent.parent / "scripts" / "run_worker.py"
+    tree = ast.parse(script_path.read_text(encoding="utf-8"))
+
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                imports.append(f"{module}.{alias.name}" if module else alias.name)
+
+    assert any(imp == "app.tasks" or imp.startswith("app.tasks.") for imp in imports), (
+        "scripts/run_worker.py must eagerly import app.tasks"
+    )
+
+
+@patch("scripts.run_worker.redis.from_url")
+@patch("scripts.run_worker.Worker")
+def test_worker_default_queues(mock_worker_cls, mock_redis_from_url):
+    mock_redis = MagicMock()
+    mock_redis_from_url.return_value = mock_redis
+    mock_worker = MagicMock()
+    mock_worker_cls.return_value = mock_worker
+
+    main([])
+
+    mock_redis.ping.assert_called_once()
+    mock_worker_cls.assert_called_once_with(
+        ["light", "heavy"], connection=mock_redis, name=None
+    )
+    mock_worker.work.assert_called_once_with(burst=False)
+
+
+@patch("scripts.run_worker.redis.from_url")
+@patch("scripts.run_worker.Worker")
+def test_worker_explicit_queues(mock_worker_cls, mock_redis_from_url):
+    mock_redis = MagicMock()
+    mock_redis_from_url.return_value = mock_redis
+    mock_worker = MagicMock()
+    mock_worker_cls.return_value = mock_worker
+
+    main(["light"])
+    mock_worker_cls.assert_called_with(["light"], connection=mock_redis, name=None)
+
+    main(["heavy"])
+    mock_worker_cls.assert_called_with(["heavy"], connection=mock_redis, name=None)
+
+    main(["light", "heavy", "custom_queue"])
+    mock_worker_cls.assert_called_with(
+        ["light", "heavy", "custom_queue"], connection=mock_redis, name=None
+    )
+
+
+@patch("scripts.run_worker.redis.from_url")
+@patch("scripts.run_worker.Worker")
+def test_worker_burst_and_name_flags(mock_worker_cls, mock_redis_from_url):
+    mock_redis = MagicMock()
+    mock_redis_from_url.return_value = mock_redis
+    mock_worker = MagicMock()
+    mock_worker_cls.return_value = mock_worker
+
+    main(["light", "--burst", "--name", "test-worker-1"])
+    mock_worker_cls.assert_called_once_with(
+        ["light"], connection=mock_redis, name="test-worker-1"
+    )
+    mock_worker.work.assert_called_once_with(burst=True)
+
+
+@patch("scripts.run_worker.redis.from_url")
+def test_worker_redis_connection_error_fast_fail(mock_redis_from_url, capsys):
+    mock_redis = MagicMock()
+    mock_redis.ping.side_effect = redis.exceptions.ConnectionError(
+        "Connection refused by Redis server"
+    )
+    mock_redis_from_url.return_value = mock_redis
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["light"])
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Error: Could not connect to Redis" in captured.err, (
+        f"Expected clean error on stderr, got: {captured.err}"
+    )
+    assert "Connection refused" in captured.err
+
+
+def test_worker_redis_url_unset_fast_fail(capsys):
+    with patch("scripts.run_worker.settings.redis_url", ""):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["light"])
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Error: REDIS_URL is unset." in captured.err
+
+
+def test_worker_cli_help():
+    result = subprocess.run(
+        [sys.executable, "scripts/run_worker.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Run an RQ worker for VEditor" in result.stdout
+    assert "queues" in result.stdout


### PR DESCRIPTION
# Closes #164 
This PR implements the dedicated RQ worker runner wrapper script (`scripts/run_worker.py`) for Phase 4 Issue 3.

It replaces direct `rq worker` CLI invocations with a centralized runner that:
1. Sources Redis configuration directly from `app.config.settings` (`REDIS_URL`), avoiding repetitive CLI arguments.
2. Eagerly preloads task modules (`app.tasks`) once at worker boot rather than paying re-import overhead on each job fork (per RQ performance best practices).
3. Performs a fast-fail health check (`ping()`) against Redis before entering the worker loop, exiting with code `1` and a readable error on `stderr` instead of an unhandled traceback.
4. Accepts custom queue names via CLI arguments (defaulting to `light heavy`) along with `--burst` and `--name` options.

## Changes
- **`scripts/run_worker.py`**: Custom worker runner script.
- **`app/tasks.py`**: Placeholder module for stage wrappers eagerly imported by the worker.
- **`docker-compose.yml`**: Updated `worker-light` and `worker-heavy` services to invoke `uv run python scripts/run_worker.py`.
- **`tests/test_worker.py`**: Comprehensive unit tests covering default/custom queue resolution, fast-fail error handling, CLI flags, and AST-level eager import verification.
- **`README.md`**, **`AGENTS.md`**, **`GEMINI.md`**: Updated documentation for starting native workers.

## Worker command
Run the following command to run the rq workers
```bash
 uv run python scripts/run_worker.py light heavy
```


## Testing Commands

1. Run unit tests for the worker runner
```bash
uv run pytest tests/test_worker.py -v
```

2. Run full project test suite
```bash
uv run pytest
```

3. Verify CLI help output
```bash
uv run python scripts/run_worker.py --help
```

4. Verify fast-fail on unreachable Redis
```bash
REDIS_URL="redis://localhost:9999/0" uv run python scripts/run_worker.py light
```

## Summary by Sourcery

Introduce a centralized RQ worker startup path with safer Redis initialization and flexible worker configuration.

New Features:
- Add a dedicated RQ worker runner supporting configurable queues, burst mode, and worker names.
- Preload task modules and validate Redis connectivity before starting workers.

Bug Fixes:
- Provide clear fast-fail errors when Redis configuration is missing or unreachable.

Enhancements:
- Centralize worker startup configuration through application settings instead of direct RQ CLI options.

Build:
- Include the worker runner scripts in the container image.

Deployment:
- Update Docker Compose worker services to use the centralized worker runner.

Documentation:
- Update native worker startup instructions to use the new runner.

Tests:
- Add coverage for queue selection, worker options, eager task imports, CLI help, and Redis startup failures.