### PR TITLE
feat(pipeline): implement final publish stage with storage boundary enforcement

### DIFF
--- a/app/pipeline/publish.py
+++ b/app/pipeline/publish.py
@@ -1,0 +1,24 @@
+"""Final pipeline stage: publishes transcoded media into storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.storage import StorageBackend
+
+
+def publish(local_path: Path | str, talk_id: int, backend: StorageBackend) -> str:
+    """Move transcoded media output to published storage and return its URL.
+
+    Args:
+        local_path: Local filesystem path to the transcoded output.
+        talk_id: Identifier of the associated talk.
+        backend: Target storage backend abstraction.
+
+    Returns:
+        The URL/URI string for the published media asset.
+    """
+    path = Path(local_path)
+    key = f"{talk_id}/final/{path.name}"
+    backend.put(key, source=path)
+    return backend.url(key)

--- a/tests/pipeline/test_publish.py
+++ b/tests/pipeline/test_publish.py
@@ -1,0 +1,122 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.pipeline.publish import publish
+from app.storage import LocalDiskBackend
+from tests.conftest import FakeStorageBackend, generate_clip
+from tests.test_pipeline_imports import is_forbidden
+from tests.test_storage_boundary import find_storage_violations
+
+
+def test_publish_stores_at_expected_key_and_returns_url(
+    tmp_path: Path, fake_storage: FakeStorageBackend
+):
+    clip = generate_clip(1.0, output_dir=tmp_path)
+    expected_key = f"42/final/{clip.name}"
+
+    url = publish(clip, talk_id=42, backend=fake_storage)
+
+    assert url == fake_storage.url(expected_key)
+    assert fake_storage.exists(expected_key)
+    stored_path = fake_storage.get(expected_key)
+    assert stored_path.read_bytes() == clip.read_bytes()
+
+
+def test_publish_overwrites_cleanly(tmp_path: Path, fake_storage: FakeStorageBackend):
+    v1_dir = tmp_path / "v1"
+    v2_dir = tmp_path / "v2"
+    v1_dir.mkdir()
+    v2_dir.mkdir()
+
+    clip_v1 = generate_clip(1.0, output_dir=v1_dir)
+    filename = clip_v1.name
+    expected_key = f"42/final/{filename}"
+
+    publish(clip_v1, talk_id=42, backend=fake_storage)
+    assert fake_storage.get(expected_key).read_bytes() == clip_v1.read_bytes()
+
+    # Create distinct version 2 with identical filename
+    clip_v2_temp = generate_clip(2.0, output_dir=v2_dir)
+    clip_v2 = v2_dir / filename
+    clip_v2_temp.rename(clip_v2)
+
+    url_v2 = publish(clip_v2, talk_id=42, backend=fake_storage)
+
+    assert url_v2 == fake_storage.url(expected_key)
+    assert fake_storage.get(expected_key).read_bytes() == clip_v2.read_bytes()
+
+
+def test_publish_with_local_disk_backend(tmp_path: Path):
+    storage_root = tmp_path / "storage"
+    backend = LocalDiskBackend(storage_root)
+    clip = generate_clip(1.0, output_dir=tmp_path / "source")
+    expected_key = f"99/final/{clip.name}"
+
+    url = publish(clip, talk_id=99, backend=backend)
+
+    assert backend.exists(expected_key)
+    assert url == backend.url(expected_key)
+    assert url.startswith("file://")
+    stored_file = backend.get(expected_key)
+    assert stored_file.read_bytes() == clip.read_bytes()
+
+
+def test_publish_storage_boundary_isolated():
+    publish_path = (
+        Path(__file__).parent.parent.parent / "app" / "pipeline" / "publish.py"
+    )
+    source_code = publish_path.read_text(encoding="utf-8")
+    violations = find_storage_violations(source_code, file_path=str(publish_path.name))
+
+    assert violations == [], (
+        f"Storage boundary violations found in publish.py: {violations}"
+    )
+
+
+def test_publish_pipeline_imports_isolated():
+    publish_path = (
+        Path(__file__).parent.parent.parent / "app" / "pipeline" / "publish.py"
+    )
+    source_code = publish_path.read_text(encoding="utf-8")
+    tree = ast.parse(source_code)
+
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if is_forbidden(alias.name):
+                    violations.append(
+                        f"Direct import of forbidden module: {alias.name}"
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            module_name = node.module or ""
+            if node.level >= 2:
+                module_name = f"app.{module_name}" if module_name else "app"
+            for alias in node.names:
+                full_name = f"{module_name}.{alias.name}" if module_name else alias.name
+                if is_forbidden(module_name) or is_forbidden(full_name):
+                    violations.append(
+                        f"Import of forbidden module: {full_name} from {node.module}"
+                    )
+
+    assert violations == [], f"Forbidden imports found in publish.py: {violations}"
+
+
+def test_publish_nonexistent_file_raises_error(
+    tmp_path: Path, fake_storage: FakeStorageBackend
+):
+    missing_clip = tmp_path / "nonexistent.mp4"
+    with pytest.raises(FileNotFoundError):
+        publish(missing_clip, talk_id=42, backend=fake_storage)
+
+
+def test_publish_accepts_str_path(tmp_path: Path, fake_storage: FakeStorageBackend):
+    clip = generate_clip(1.0, output_dir=tmp_path)
+    expected_key = f"42/final/{clip.name}"
+
+    url = publish(str(clip), talk_id=42, backend=fake_storage)
+
+    assert url == fake_storage.url(expected_key)
+    assert fake_storage.exists(expected_key)


### PR DESCRIPTION
# Closes #155 
Implements the final pipeline stage (`app/pipeline/publish.py`) that moves transcoded video assets into their published storage location under the `{talk_id}/final/{filename}` key convention and returns the resulting asset URL.

In accordance with architectural invariants, `publish.py` performs no direct filesystem I/O (`open`, `shutil`, `os`, `Path.write_*`/`Path.read_*`) and imports zero framework/DB packages (`fastapi`, `rq`, `sqlalchemy`, `app.db`), delegating all storage operations to the injected `StorageBackend`.

## Key Changes
- **Pipeline Implementation** (`app/pipeline/publish.py`):
  - Added `publish(local_path: Path | str, talk_id: int, backend: StorageBackend) -> str`.
  - Normalizes input paths, builds `{talk_id}/final/{filename}` storage keys, and triggers atomic file placement via `backend.put()`.
  - Returns `backend.url(key)`.
- **Test Suite** (`tests/pipeline/test_publish.py`):
  - Unit tests with `FakeStorageBackend` verifying key formatting, URL output, and byte integrity.
  - Overwrite tests verifying clean re-publish semantics during `needs_work` loop re-transcodes.
  - Integration tests with `LocalDiskBackend` validating file placement and `file://` URI formatting.
  - Failure path tests verifying `FileNotFoundError` for missing source files.
  - Parameter flexibility tests for both `Path` and `str` inputs.
  - Isolated AST storage boundary scan asserting 0 direct I/O calls.
  - Isolated AST import guard check asserting 0 forbidden framework/DB imports.

## Verification
- `uv run pytest tests/pipeline/test_publish.py -v`: 7 passed in 0.46s
- `uv run pytest tests/test_storage_boundary.py tests/test_pipeline_imports.py -v`: 5 passed in 0.07s
- `uv run pytest`: 128 passed in 11.46s

## Summary by Sourcery

Publish transcoded media through the injected storage backend and expose the resulting asset URL.

New Features:
- Add the final pipeline publish stage, placing transcoded assets under the `{talk_id}/final/{filename}` convention and returning their storage URL.

Enhancements:
- Enforce storage abstraction and framework-independent boundaries for publishing operations.

Tests:
- Add unit, integration, overwrite, failure-path, input-flexibility, and architectural boundary coverage for publishing.