### PR TITLE
feat(auth): add admin endpoints, operational CLI commands, and lifecycle test suite

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -45,6 +45,18 @@ def hash_api_key(api_key: str) -> str:
     return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
 
 
+def lock_active_admins(session: Session) -> list[int]:
+    """Locks active administrator rows in ascending ID order and returns their IDs."""
+    rows = (
+        session.query(models.User.id)
+        .filter(models.User.role == "admin", models.User.is_active.is_(True))
+        .order_by(models.User.id.asc())
+        .with_for_update()
+        .all()
+    )
+    return [r[0] if isinstance(r, (tuple, list)) else getattr(r, "id", r) for r in rows]
+
+
 def get_client(
     api_key: Annotated[str | None, Security(api_key_header)],
     db: Annotated[Session, Depends(get_db)],

--- a/app/auth.py
+++ b/app/auth.py
@@ -271,6 +271,21 @@ def require_role(min_role: Literal["user", "organizer", "admin"] | str):
     return _role_checker
 
 
+def require_admin(
+    user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> CurrentUser:
+    """
+    Dependency enforcing that the caller is an authenticated human administrator
+    (cookie or JWT session with user_id set), rejecting machine API key clients.
+    """
+    if not user.is_human_admin or user.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation requires a human administrator",
+        )
+    return user
+
+
 def check_event_access(
     event_id: int,
     user: CurrentUser,

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,11 +1,12 @@
 import argparse
+import getpass
 import secrets
 import sys
 
 from sqlalchemy.orm import Session
 
 from app import models
-from app.auth import hash_api_key
+from app.auth import hash_api_key, lock_active_admins
 from app.db import SessionLocal
 from app.security import hash_password, is_valid_email
 
@@ -92,12 +93,9 @@ def promote_user(session: Session, email: str, role: str):
         sys.exit(1)
 
     if user.role == "admin" and user.is_active and role != "admin":
-        admin_count = (
-            session.query(models.User)
-            .filter(models.User.role == "admin", models.User.is_active.is_(True))
-            .count()
-        )
-        if admin_count <= 1:
+        admin_ids = lock_active_admins(session)
+        session.refresh(user)
+        if user.role == "admin" and user.is_active and len(admin_ids) <= 1:
             print(
                 "Error: Cannot demote user; operation would leave zero active administrators."
             )
@@ -153,12 +151,6 @@ def main():
     create_admin_parser.add_argument(
         "--email", type=str, required=True, help="Email address of the administrator"
     )
-    create_admin_parser.add_argument(
-        "--password",
-        type=str,
-        required=True,
-        help="Password for the administrator (minimum 8 characters)",
-    )
 
     # `admin promote-user` command
     promote_user_parser = admin_subparsers.add_parser(
@@ -186,7 +178,11 @@ def main():
             if args.subcommand == "create-client":
                 create_client(db, args.event_name, args.event_id)
             elif args.subcommand == "create-admin":
-                create_admin(db, args.email, args.password)
+                if not sys.stdin.isatty():
+                    password = sys.stdin.readline().rstrip("\r\n")
+                else:
+                    password = getpass.getpass("Password: ")
+                create_admin(db, args.email, password)
             elif args.subcommand == "promote-user":
                 promote_user(db, args.email, args.role)
             elif args.subcommand == "list-users":

--- a/app/cli.py
+++ b/app/cli.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from app import models
 from app.auth import hash_api_key
 from app.db import SessionLocal
+from app.security import hash_password, is_valid_email
 
 
 def create_client(session: Session, event_name: str | None, event_id: int | None):
@@ -50,6 +51,80 @@ def create_client(session: Session, event_name: str | None, event_id: int | None
     print("Store this key safely! It will not be shown again.")
 
 
+def create_admin(session: Session, email: str, password: str):
+    clean_email = email.strip().lower() if email else ""
+    if not is_valid_email(clean_email):
+        print("Error: Invalid email format.")
+        sys.exit(1)
+
+    if not password or len(password) < 8:
+        print("Error: Password must be at least 8 characters long.")
+        sys.exit(1)
+
+    existing = (
+        session.query(models.User).filter(models.User.email == clean_email).first()
+    )
+    if existing:
+        print(f"Error: User with email '{clean_email}' already exists.")
+        sys.exit(1)
+
+    user = models.User(
+        email=clean_email,
+        hashed_password=hash_password(password),
+        role="admin",
+        is_active=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    print(f"Created admin user '{user.email}' with ID {user.id}")
+
+
+def promote_user(session: Session, email: str, role: str):
+    clean_email = email.strip().lower() if email else ""
+    user = session.query(models.User).filter(models.User.email == clean_email).first()
+    if not user:
+        print(f"Error: User with email '{clean_email}' not found.")
+        sys.exit(1)
+
+    if role not in ("user", "organizer", "admin"):
+        print(f"Error: Invalid role '{role}'. Must be one of: user, organizer, admin.")
+        sys.exit(1)
+
+    if user.role == "admin" and user.is_active and role != "admin":
+        admin_count = (
+            session.query(models.User)
+            .filter(models.User.role == "admin", models.User.is_active.is_(True))
+            .count()
+        )
+        if admin_count <= 1:
+            print(
+                "Error: Cannot demote user; operation would leave zero active administrators."
+            )
+            sys.exit(1)
+
+    user.role = role
+    session.commit()
+    session.refresh(user)
+    print(f"Updated user '{user.email}' role to '{user.role}'.")
+
+
+def list_users(session: Session):
+    users = session.query(models.User).order_by(models.User.id.asc()).all()
+    if not users:
+        print("No users found.")
+        return
+
+    header = f"{'ID':<6} {'Email':<32} {'Role':<12} {'Active':<8} {'Created At'}"
+    print(header)
+    print("-" * len(header))
+    for u in users:
+        created_str = (
+            u.created_at.strftime("%Y-%m-%d %H:%M:%S") if u.created_at else "N/A"
+        )
+        print(f"{u.id:<6} {u.email:<32} {u.role:<12} {u.is_active!s:<8} {created_str}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="VEditor CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -71,12 +146,51 @@ def main():
         "--event-id", type=int, help="ID of an existing event to scope the client to"
     )
 
+    # `admin create-admin` command
+    create_admin_parser = admin_subparsers.add_parser(
+        "create-admin", help="Create a new administrator user"
+    )
+    create_admin_parser.add_argument(
+        "--email", type=str, required=True, help="Email address of the administrator"
+    )
+    create_admin_parser.add_argument(
+        "--password",
+        type=str,
+        required=True,
+        help="Password for the administrator (minimum 8 characters)",
+    )
+
+    # `admin promote-user` command
+    promote_user_parser = admin_subparsers.add_parser(
+        "promote-user", help="Promote or update a user's role"
+    )
+    promote_user_parser.add_argument(
+        "--email", type=str, required=True, help="Email address of the user"
+    )
+    promote_user_parser.add_argument(
+        "--role",
+        type=str,
+        required=True,
+        choices=["user", "organizer", "admin"],
+        help="Target role (user, organizer, admin)",
+    )
+
+    # `admin list-users` command
+    admin_subparsers.add_parser("list-users", help="List all registered users")
+
     args = parser.parse_args()
 
-    if args.command == "admin" and args.subcommand == "create-client":
+    if args.command == "admin":
         db = SessionLocal()
         try:
-            create_client(db, args.event_name, args.event_id)
+            if args.subcommand == "create-client":
+                create_client(db, args.event_name, args.event_id)
+            elif args.subcommand == "create-admin":
+                create_admin(db, args.email, args.password)
+            elif args.subcommand == "promote-user":
+                promote_user(db, args.email, args.role)
+            elif args.subcommand == "list-users":
+                list_users(db)
         finally:
             db.close()
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,13 +5,14 @@ from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.queue import redis_conn
-from app.routes import auth, jobs, ops, reviews, studio, talks
+from app.routes import admin, auth, jobs, ops, reviews, studio, talks
 
 app = FastAPI(title="VEditor API")
 
 _STATIC_DIR = Path(__file__).parent / "ui" / "static"
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
 
+app.include_router(admin.router)
 app.include_router(auth.router)
 app.include_router(ops.router)
 app.include_router(talks.router)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app import models, schemas
-from app.auth import CurrentUser, get_current_user, require_role
+from app.auth import CurrentUser, get_current_user, lock_active_admins, require_role
 from app.db import get_db
 
 router = APIRouter(
@@ -43,13 +43,9 @@ def promote_user(
         )
 
     if target.role == "admin" and target.is_active and payload.role != "admin":
-        admin_ids = (
-            db.query(models.User.id)
-            .filter(models.User.role == "admin", models.User.is_active.is_(True))
-            .with_for_update()
-            .all()
-        )
-        if len(admin_ids) <= 1:
+        admin_ids = lock_active_admins(db)
+        db.refresh(target)
+        if target.role == "admin" and target.is_active and len(admin_ids) <= 1:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Cannot demote user; operation would leave zero active administrators",
@@ -81,13 +77,9 @@ def deactivate_user(
         )
 
     if target.role == "admin" and target.is_active:
-        admin_ids = (
-            db.query(models.User.id)
-            .filter(models.User.role == "admin", models.User.is_active.is_(True))
-            .with_for_update()
-            .all()
-        )
-        if len(admin_ids) <= 1:
+        admin_ids = lock_active_admins(db)
+        db.refresh(target)
+        if target.role == "admin" and target.is_active and len(admin_ids) <= 1:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Cannot deactivate the last active administrator",

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,0 +1,99 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app import models, schemas
+from app.auth import CurrentUser, get_current_user, require_role
+from app.db import get_db
+
+router = APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    dependencies=[Depends(require_role("admin"))],
+)
+
+
+@router.get("/users", response_model=list[schemas.UserRead])
+def list_users(
+    db: Annotated[Session, Depends(get_db)],
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+):
+    return (
+        db.query(models.User)
+        .order_by(models.User.id.asc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+@router.post("/users/{id}/promote", response_model=schemas.UserRead)
+def promote_user(
+    id: int,
+    payload: schemas.UserPromoteRequest,
+    db: Annotated[Session, Depends(get_db)],
+):
+    target = db.query(models.User).filter(models.User.id == id).first()
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    if target.role == "admin" and target.is_active and payload.role != "admin":
+        admin_ids = (
+            db.query(models.User.id)
+            .filter(models.User.role == "admin", models.User.is_active.is_(True))
+            .with_for_update()
+            .all()
+        )
+        if len(admin_ids) <= 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot demote user; operation would leave zero active administrators",
+            )
+
+    target.role = payload.role
+    db.commit()
+    db.refresh(target)
+    return target
+
+
+@router.post("/users/{id}/deactivate", response_model=schemas.UserRead)
+def deactivate_user(
+    id: int,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    if current_user.user_id is not None and current_user.user_id == id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot deactivate your own account",
+        )
+
+    target = db.query(models.User).filter(models.User.id == id).first()
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    if target.role == "admin" and target.is_active:
+        admin_ids = (
+            db.query(models.User.id)
+            .filter(models.User.role == "admin", models.User.is_active.is_(True))
+            .with_for_update()
+            .all()
+        )
+        if len(admin_ids) <= 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot deactivate the last active administrator",
+            )
+
+    target.is_active = False
+    db.commit()
+    db.refresh(target)
+    return target

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -4,13 +4,18 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app import models, schemas
-from app.auth import CurrentUser, get_current_user, lock_active_admins, require_role
+from app.auth import (
+    CurrentUser,
+    get_current_user,
+    lock_active_admins,
+    require_admin,
+)
 from app.db import get_db
 
 router = APIRouter(
     prefix="/admin",
     tags=["admin"],
-    dependencies=[Depends(require_role("admin"))],
+    dependencies=[Depends(require_admin)],
 )
 
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import re
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
@@ -16,6 +15,7 @@ from app.security import (
     create_session_token,
     decode_session_token,
     hash_password,
+    is_valid_email,
     verify_password,
 )
 from app.ui.templating import templates
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["auth"])
 
-EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _DUMMY_HASH = hash_password("veditor-timing-defense-sentinel")
 
 
@@ -128,7 +127,7 @@ def signup_submit(
     password_confirm: Annotated[str, Form()] = "",
 ):
     clean_email = email.strip().lower()
-    if len(clean_email) > 255 or not EMAIL_REGEX.match(clean_email):
+    if len(clean_email) > 255 or not is_valid_email(clean_email):
         return templates.TemplateResponse(
             request,
             "signup.html.jinja",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -281,6 +281,19 @@ class TokenResponse(BaseModel):
     expires_in: int
 
 
+class UserRead(BaseModel):
+    id: int
+    email: str
+    role: str
+    is_active: bool
+    created_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserPromoteRequest(BaseModel):
+    role: Literal["user", "organizer", "admin"]
+
+
 class TalkUpdate(BaseModel):
     title: str | None = None
     room: str | None = None

--- a/app/security.py
+++ b/app/security.py
@@ -204,9 +204,8 @@ def is_valid_email(email: str) -> bool:
         return bool(
             addr.username
             and addr.domain
-            and "." in addr.domain
             and not addr.domain.startswith(".")
             and not addr.domain.endswith(".")
         )
-    except HeaderParseError, ValueError, IndexError, TypeError:
+    except (HeaderParseError, ValueError, IndexError, TypeError) as _exc:
         return False

--- a/app/security.py
+++ b/app/security.py
@@ -1,6 +1,8 @@
 import os
 import secrets
 from datetime import UTC, datetime, timedelta
+from email.errors import HeaderParseError
+from email.headerregistry import Address
 from pathlib import Path
 
 import jwt
@@ -190,3 +192,21 @@ def decode_access_token(token: str) -> dict | None:
         return payload
     except (jwt.PyJWTError, TypeError, ValueError, AttributeError) as _exc:
         return None
+
+
+def is_valid_email(email: str) -> bool:
+    """Validates an email address against RFC 5322 using the Python standard library."""
+    if not email or not isinstance(email, str) or "@" not in email:
+        return False
+    try:
+        clean = email.strip()
+        addr = Address(addr_spec=clean)
+        return bool(
+            addr.username
+            and addr.domain
+            and "." in addr.domain
+            and not addr.domain.startswith(".")
+            and not addr.domain.endswith(".")
+        )
+    except HeaderParseError, ValueError, IndexError, TypeError:
+        return False

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -410,3 +410,69 @@ def test_deactivated_user_immediate_session_and_login_rejection(
     )
     assert res_token_post.status_code == 401
     assert res_token_post.json()["detail"] == "Invalid credentials"
+
+
+def test_concurrent_admin_demotion_prevents_zero_admins():
+    import threading
+
+    with SessionLocal() as s:
+        s.query(models.User).filter(
+            models.User.email.like("%@concurrent-test.com")
+        ).delete()
+        s.commit()
+        admin1 = models.User(
+            email="admin1@concurrent-test.com",
+            hashed_password=hash_password("pw1"),
+            role="admin",
+            is_active=True,
+        )
+        admin2 = models.User(
+            email="admin2@concurrent-test.com",
+            hashed_password=hash_password("pw2"),
+            role="admin",
+            is_active=True,
+        )
+        s.add_all([admin1, admin2])
+        s.commit()
+        id1, id2 = admin1.id, admin2.id
+
+    token1 = create_session_token(id1, "admin")
+    token2 = create_session_token(id2, "admin")
+
+    results = []
+
+    def demote_request(token, target_id):
+        t_client = TestClient(app)
+        t_client.cookies.set("veditor_session", token)
+        res = t_client.post(
+            f"/admin/users/{target_id}/promote", json={"role": "organizer"}
+        )
+        results.append((target_id, res.status_code, res.json()))
+
+    t1 = threading.Thread(target=demote_request, args=(token1, id2))
+    t2 = threading.Thread(target=demote_request, args=(token2, id1))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # One succeeds (200), and the other fails (either 400 or 403)
+    status_codes = [r[1] for r in results]
+    assert 200 in status_codes
+    assert any(code in (400, 403) for code in status_codes)
+
+    with SessionLocal() as s:
+        remaining_admins = (
+            s.query(models.User)
+            .filter(
+                models.User.email.like("%@concurrent-test.com"),
+                models.User.role == "admin",
+                models.User.is_active.is_(True),
+            )
+            .all()
+        )
+        assert len(remaining_admins) == 1
+        s.query(models.User).filter(
+            models.User.email.like("%@concurrent-test.com")
+        ).delete()
+        s.commit()

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,0 +1,412 @@
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import models
+from app.auth import hash_api_key
+from app.db import Base, SessionLocal, engine, get_db
+from app.main import app
+from app.security import create_access_token, create_session_token, hash_password
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def db_session():
+    db = SessionLocal()
+    app.dependency_overrides[get_db] = lambda: db
+    created = []
+    orig_add = db.add
+
+    def track_add(instance):
+        created.append(instance)
+        return orig_add(instance)
+
+    db.add = track_add
+    try:
+        yield db
+    finally:
+        try:
+            db.rollback()
+            for obj in reversed(created):
+                try:
+                    db.delete(obj)
+                    db.commit()
+                except Exception:  # noqa: BLE001
+                    db.rollback()
+            try:
+                db.query(models.User).filter(
+                    models.User.email.like("%@admin-test.com")
+                ).delete()
+                db.commit()
+            except Exception:  # noqa: BLE001
+                db.rollback()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            db.close()
+
+
+def _create_test_user(
+    db, email: str, role: str = "user", is_active: bool = True
+) -> models.User:
+    user = models.User(
+        email=email,
+        hashed_password=hash_password("Password123!"),
+        role=role,
+        is_active=is_active,
+        created_at=datetime.now(UTC),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_admin_routes_unauthenticated(client: TestClient):
+    # GET /admin/users
+    res = client.get("/admin/users")
+    assert res.status_code == 401
+
+    # POST /admin/users/{id}/promote
+    res = client.post("/admin/users/1/promote", json={"role": "organizer"})
+    assert res.status_code == 401
+
+    # POST /admin/users/{id}/deactivate
+    res = client.post("/admin/users/1/deactivate")
+    assert res.status_code == 401
+
+
+def test_admin_routes_forbidden_for_non_admin(client: TestClient, db_session):
+    regular_user = _create_test_user(db_session, "regular@admin-test.com", role="user")
+    token = create_session_token(regular_user.id, regular_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.get("/admin/users")
+    assert res.status_code == 403
+    assert "admin" in res.text
+
+    organizer_user = _create_test_user(
+        db_session, "organizer@admin-test.com", role="organizer"
+    )
+    token_org = create_session_token(organizer_user.id, organizer_user.role)
+    client.cookies.set("veditor_session", token_org)
+
+    res = client.get("/admin/users")
+    assert res.status_code == 403
+
+
+def test_admin_users_list_success_and_pagination(client: TestClient, db_session):
+    admin_user = _create_test_user(db_session, "admin1@admin-test.com", role="admin")
+    u1 = _create_test_user(db_session, "alpha@admin-test.com", role="user")
+    u2 = _create_test_user(db_session, "beta@admin-test.com", role="organizer")
+
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.get("/admin/users?skip=0&limit=10")
+    assert res.status_code == 200
+    data = res.json()
+    assert isinstance(data, list)
+    user_ids = [u["id"] for u in data]
+    assert admin_user.id in user_ids
+    assert u1.id in user_ids
+    assert u2.id in user_ids
+    # Check ordering by id
+    assert user_ids == sorted(user_ids)
+
+    # Check serialization fields
+    target_data = next(u for u in data if u["id"] == u1.id)
+    assert target_data["email"] == "alpha@admin-test.com"
+    assert target_data["role"] == "user"
+    assert target_data["is_active"] is True
+    assert "created_at" in target_data
+
+    # Test limit validation
+    res_invalid_limit = client.get("/admin/users?limit=101")
+    assert res_invalid_limit.status_code == 422
+
+    res_invalid_skip = client.get("/admin/users?skip=-1")
+    assert res_invalid_skip.status_code == 422
+
+
+def test_admin_users_list_via_api_key(client: TestClient, db_session):
+    client_obj = models.Client(
+        hashed_key=hash_api_key("test-admin-api-key"),
+        event_ids=[],
+    )
+    db_session.add(client_obj)
+    db_session.commit()
+
+    res = client.get(
+        "/admin/users",
+        headers={"X-API-Key": "test-admin-api-key"},
+    )
+    assert res.status_code == 200
+    assert isinstance(res.json(), list)
+
+
+def test_promote_user_not_found(client: TestClient, db_session):
+    admin_user = _create_test_user(db_session, "admin_p1@admin-test.com", role="admin")
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.post("/admin/users/999999/promote", json={"role": "organizer"})
+    assert res.status_code == 404
+    assert res.json()["detail"] == "User not found"
+
+
+def test_promote_user_invalid_role_payload(client: TestClient, db_session):
+    admin_user = _create_test_user(db_session, "admin_p2@admin-test.com", role="admin")
+    target_user = _create_test_user(db_session, "target_p2@admin-test.com", role="user")
+
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    # Only "organizer" and "admin" are permitted in schemas.UserPromoteRequest
+    res = client.post(
+        f"/admin/users/{target_user.id}/promote", json={"role": "invalid"}
+    )
+    assert res.status_code == 422
+
+
+def test_promote_user_success(client: TestClient, db_session):
+    admin_user = _create_test_user(db_session, "admin_p3@admin-test.com", role="admin")
+    target_user = _create_test_user(db_session, "target_p3@admin-test.com", role="user")
+
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.post(
+        f"/admin/users/{target_user.id}/promote", json={"role": "organizer"}
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["id"] == target_user.id
+    assert data["role"] == "organizer"
+
+    db_session.refresh(target_user)
+    assert target_user.role == "organizer"
+
+    # Now promote to admin
+    res2 = client.post(f"/admin/users/{target_user.id}/promote", json={"role": "admin"})
+    assert res2.status_code == 200
+    assert res2.json()["role"] == "admin"
+
+
+def test_promote_guard_cannot_demote_last_admin(client: TestClient, db_session):
+    # Ensure only 1 active admin exists in db
+    db_session.query(models.User).filter(models.User.role == "admin").delete()
+    db_session.commit()
+
+    admin_user = _create_test_user(
+        db_session, "sole_admin@admin-test.com", role="admin"
+    )
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    # Demoting the sole active admin
+    res = client.post(
+        f"/admin/users/{admin_user.id}/promote", json={"role": "organizer"}
+    )
+    assert res.status_code == 400
+    assert (
+        res.json()["detail"]
+        == "Cannot demote user; operation would leave zero active administrators"
+    )
+
+
+def test_promote_demote_admin_allowed_if_another_admin_exists(
+    client: TestClient, db_session
+):
+    admin1 = _create_test_user(db_session, "admin_a@admin-test.com", role="admin")
+    admin2 = _create_test_user(db_session, "admin_b@admin-test.com", role="admin")
+
+    token = create_session_token(admin1.id, admin1.role)
+    client.cookies.set("veditor_session", token)
+
+    # Demoting admin2 should succeed because admin1 remains active
+    res = client.post(f"/admin/users/{admin2.id}/promote", json={"role": "organizer"})
+    assert res.status_code == 200
+    assert res.json()["role"] == "organizer"
+
+    db_session.refresh(admin2)
+    assert admin2.role == "organizer"
+
+
+def test_deactivate_self_prevented(client: TestClient, db_session):
+    admin_user = _create_test_user(
+        db_session, "self_deact@admin-test.com", role="admin"
+    )
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.post(f"/admin/users/{admin_user.id}/deactivate")
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Cannot deactivate your own account"
+
+
+def test_deactivate_user_not_found(client: TestClient, db_session):
+    admin_user = _create_test_user(db_session, "admin_d1@admin-test.com", role="admin")
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.post("/admin/users/999999/deactivate")
+    assert res.status_code == 404
+    assert res.json()["detail"] == "User not found"
+
+
+def test_deactivate_guard_cannot_deactivate_last_admin(client: TestClient, db_session):
+    # Using API key client (has no user_id, so self-deactivate guard does not fire)
+    client_obj = models.Client(
+        hashed_key=hash_api_key("api-key-deact"),
+        event_ids=[],
+    )
+    db_session.add(client_obj)
+
+    # Ensure only 1 active admin
+    db_session.query(models.User).filter(models.User.role == "admin").delete()
+    db_session.commit()
+
+    sole_admin = _create_test_user(
+        db_session, "sole_adm_d@admin-test.com", role="admin"
+    )
+
+    res = client.post(
+        f"/admin/users/{sole_admin.id}/deactivate",
+        headers={"X-API-Key": "api-key-deact"},
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Cannot deactivate the last active administrator"
+
+
+def test_deactivate_user_success(client: TestClient, db_session):
+    admin_user = _create_test_user(db_session, "admin_d2@admin-test.com", role="admin")
+    target_user = _create_test_user(db_session, "target_d2@admin-test.com", role="user")
+
+    token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.post(f"/admin/users/{target_user.id}/deactivate")
+    assert res.status_code == 200
+    assert res.json()["is_active"] is False
+
+    db_session.refresh(target_user)
+    assert target_user.is_active is False
+
+
+def test_deactivate_admin_when_another_admin_exists(client: TestClient, db_session):
+    admin1 = _create_test_user(db_session, "admin_x@admin-test.com", role="admin")
+    admin2 = _create_test_user(db_session, "admin_y@admin-test.com", role="admin")
+
+    token = create_session_token(admin1.id, admin1.role)
+    client.cookies.set("veditor_session", token)
+
+    res = client.post(f"/admin/users/{admin2.id}/deactivate")
+    assert res.status_code == 200
+    assert res.json()["is_active"] is False
+
+    db_session.refresh(admin2)
+    assert admin2.is_active is False
+
+
+def test_deactivated_user_immediate_session_and_login_rejection(
+    client: TestClient, db_session
+):
+    admin_user = _create_test_user(
+        db_session, "admin_deact_mgr@admin-test.com", role="admin"
+    )
+    user_password = "KnownUserPassword123!"
+    user = models.User(
+        email="deact_target@admin-test.com",
+        hashed_password=hash_password(user_password),
+        role="user",
+        is_active=True,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    # Generate session cookie and bearer JWT for the user
+    cookie_token = create_session_token(user.id, user.role)
+    bearer_token = create_access_token(user.id, user.email, user.role)
+
+    # Verify that prior to deactivation, the user can authenticate with the cookie or bearer token
+    # On an admin route, regular user auth succeeds (403 Forbidden due to role check, not 401 Unauthorized)
+    client.cookies.set("veditor_session", cookie_token)
+    res_cookie_pre = client.get("/admin/users")
+    client.cookies.clear()
+    assert res_cookie_pre.status_code == 403
+    assert res_cookie_pre.json()["detail"] == "Operation requires minimum role 'admin'"
+
+    res_bearer_pre = client.get(
+        "/admin/users", headers={"Authorization": f"Bearer {bearer_token}"}
+    )
+    assert res_bearer_pre.status_code == 403
+    assert res_bearer_pre.json()["detail"] == "Operation requires minimum role 'admin'"
+
+    # Also verify login with password succeeds prior to deactivation
+    res_login_pre = client.post(
+        "/login",
+        data={"email": user.email, "password": user_password},
+        follow_redirects=False,
+    )
+    assert res_login_pre.status_code == 303
+
+    res_token_pre = client.post(
+        "/api/auth/token",
+        json={"email": user.email, "password": user_password},
+    )
+    assert res_token_pre.status_code == 200
+
+    # Admin calls POST /admin/users/{user.id}/deactivate
+    admin_token = create_session_token(admin_user.id, admin_user.role)
+    client.cookies.set("veditor_session", admin_token)
+    res_deact = client.post(f"/admin/users/{user.id}/deactivate")
+    assert res_deact.status_code == 200
+    assert res_deact.json()["is_active"] is False
+
+    # Clear admin cookie from client
+    client.cookies.clear()
+
+    # Verify that immediately after deactivation:
+    # - Request with the pre-existing session cookie returns HTTP 401 Unauthorized ("User account not found or inactive")
+    client.cookies.set("veditor_session", cookie_token)
+    res_cookie_post = client.get("/admin/users")
+    client.cookies.clear()
+    assert res_cookie_post.status_code == 401
+    assert res_cookie_post.json()["detail"] == "User account not found or inactive"
+
+    # - Request with the pre-existing JWT bearer token returns HTTP 401 Unauthorized
+    res_bearer_post = client.get(
+        "/admin/users", headers={"Authorization": f"Bearer {bearer_token}"}
+    )
+    assert res_bearer_post.status_code == 401
+    assert res_bearer_post.json()["detail"] == "User account not found or inactive"
+
+    # - POST /login with the user's password returns HTTP 400 Bad Request ("Invalid email or password.")
+    res_login_post = client.post(
+        "/login",
+        data={"email": user.email, "password": user_password},
+        follow_redirects=False,
+    )
+    assert res_login_post.status_code == 400
+    assert "Invalid email or password." in res_login_post.text
+
+    # - POST /api/auth/token returns HTTP 401 Unauthorized ("Invalid credentials")
+    res_token_post = client.post(
+        "/api/auth/token",
+        json={"email": user.email, "password": user_password},
+    )
+    assert res_token_post.status_code == 401
+    assert res_token_post.json()["detail"] == "Invalid credentials"

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app import models
-from app.auth import hash_api_key
+from app.auth import CurrentUser, hash_api_key
 from app.db import Base, SessionLocal, engine, get_db
 from app.main import app
 from app.security import create_access_token, create_session_token, hash_password
@@ -139,7 +139,7 @@ def test_admin_users_list_success_and_pagination(client: TestClient, db_session)
     assert res_invalid_skip.status_code == 422
 
 
-def test_admin_users_list_via_api_key(client: TestClient, db_session):
+def test_admin_routes_reject_api_key(client: TestClient, db_session):
     client_obj = models.Client(
         hashed_key=hash_api_key("test-admin-api-key"),
         event_ids=[],
@@ -151,8 +151,8 @@ def test_admin_users_list_via_api_key(client: TestClient, db_session):
         "/admin/users",
         headers={"X-API-Key": "test-admin-api-key"},
     )
-    assert res.status_code == 200
-    assert isinstance(res.json(), list)
+    assert res.status_code == 403
+    assert res.json()["detail"] == "Operation requires a human administrator"
 
 
 def test_promote_user_not_found(client: TestClient, db_session):
@@ -266,13 +266,6 @@ def test_deactivate_user_not_found(client: TestClient, db_session):
 
 
 def test_deactivate_guard_cannot_deactivate_last_admin(client: TestClient, db_session):
-    # Using API key client (has no user_id, so self-deactivate guard does not fire)
-    client_obj = models.Client(
-        hashed_key=hash_api_key("api-key-deact"),
-        event_ids=[],
-    )
-    db_session.add(client_obj)
-
     # Ensure only 1 active admin
     db_session.query(models.User).filter(models.User.role == "admin").delete()
     db_session.commit()
@@ -281,12 +274,17 @@ def test_deactivate_guard_cannot_deactivate_last_admin(client: TestClient, db_se
         db_session, "sole_adm_d@admin-test.com", role="admin"
     )
 
-    res = client.post(
-        f"/admin/users/{sole_admin.id}/deactivate",
-        headers={"X-API-Key": "api-key-deact"},
+    from app.auth import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=99999, role="admin", source="cookie"
     )
-    assert res.status_code == 400
-    assert res.json()["detail"] == "Cannot deactivate the last active administrator"
+    try:
+        res = client.post(f"/admin/users/{sole_admin.id}/deactivate")
+        assert res.status_code == 400
+        assert res.json()["detail"] == "Cannot deactivate the last active administrator"
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
 
 
 def test_deactivate_user_success(client: TestClient, db_session):
@@ -347,13 +345,13 @@ def test_deactivated_user_immediate_session_and_login_rejection(
     res_cookie_pre = client.get("/admin/users")
     client.cookies.clear()
     assert res_cookie_pre.status_code == 403
-    assert res_cookie_pre.json()["detail"] == "Operation requires minimum role 'admin'"
+    assert res_cookie_pre.json()["detail"] == "Operation requires a human administrator"
 
     res_bearer_pre = client.get(
         "/admin/users", headers={"Authorization": f"Bearer {bearer_token}"}
     )
     assert res_bearer_pre.status_code == 403
-    assert res_bearer_pre.json()["detail"] == "Operation requires minimum role 'admin'"
+    assert res_bearer_pre.json()["detail"] == "Operation requires a human administrator"
 
     # Also verify login with password succeeds prior to deactivation
     res_login_pre = client.post(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException, status
 
-from app.auth import get_client, hash_api_key, verify_event_access
-from app.models import Client
+from app.auth import get_client, hash_api_key, lock_active_admins, verify_event_access
+from app.models import Client, User
 
 
 def test_hash_api_key():
@@ -74,7 +74,7 @@ from app.auth import (
     require_event_access,
     require_role,
 )
-from app.models import Event, User
+from app.models import Event
 from app.security import create_access_token, create_session_token
 
 
@@ -531,3 +531,13 @@ def test_get_current_user_cookie_fail_fast_over_bearer():
         get_current_user(request=mock_request, db=mock_db)
     assert excinfo.value.status_code == 401
     assert "session token" in excinfo.value.detail.lower()
+
+
+def test_lock_active_admins_mock():
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.order_by.return_value.with_for_update.return_value.all.return_value = [
+        (1,),
+        (2,),
+    ]
+    admin_ids = lock_active_admins(mock_session)
+    assert admin_ids == [1, 2]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,6 +71,7 @@ from app.auth import (
     CurrentUser,
     check_event_access,
     get_current_user,
+    require_admin,
     require_event_access,
     require_role,
 )
@@ -301,6 +302,24 @@ def test_require_role_hierarchy():
     assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
 
     assert check_admin(admin_user) == admin_user
+
+
+def test_require_admin():
+    regular_user = CurrentUser(user_id=1, role="user", source="jwt")
+    machine_admin = CurrentUser(role="admin", source="api_key")
+    human_admin = CurrentUser(user_id=2, role="admin", source="cookie")
+
+    with pytest.raises(HTTPException) as excinfo:
+        require_admin(regular_user)
+    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
+    assert excinfo.value.detail == "Operation requires a human administrator"
+
+    with pytest.raises(HTTPException) as excinfo:
+        require_admin(machine_admin)
+    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
+    assert excinfo.value.detail == "Operation requires a human administrator"
+
+    assert require_admin(human_admin) == human_admin
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app import models
-from app.cli import create_client, main
+from app.cli import create_admin, create_client, list_users, main, promote_user
 
 
 @patch("app.cli.secrets.token_urlsafe")
@@ -85,7 +85,7 @@ def test_create_client_invalid_event_id():
 
 @patch("app.cli.create_client")
 @patch("app.cli.SessionLocal")
-def test_cli_main(mock_session_local, mock_create_client):
+def test_cli_main_create_client(mock_session_local, mock_create_client):
     test_args = ["veditor", "admin", "create-client", "--event-name", "Test"]
     with patch.object(sys, "argv", test_args):
         main()
@@ -94,4 +94,210 @@ def test_cli_main(mock_session_local, mock_create_client):
     mock_create_client.assert_called_once_with(
         mock_session_local.return_value, "Test", None
     )
+    mock_session_local.return_value.close.assert_called_once()
+
+
+@patch("app.cli.hash_password")
+def test_create_admin_success(mock_hash_password):
+    mock_hash_password.return_value = "hashed-secret"
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.first.return_value = None
+
+    def mock_refresh(obj):
+        obj.id = 10
+
+    mock_session.refresh.side_effect = mock_refresh
+
+    create_admin(mock_session, email="Admin@Example.COM", password="validpassword123")
+
+    mock_session.add.assert_called_once()
+    user = mock_session.add.call_args[0][0]
+    assert isinstance(user, models.User)
+    assert user.email == "admin@example.com"
+    assert user.role == "admin"
+    assert user.is_active is True
+    assert user.hashed_password == "hashed-secret"
+    mock_session.commit.assert_called_once()
+    mock_session.refresh.assert_called_once_with(user)
+
+
+def test_create_admin_invalid_email():
+    mock_session = MagicMock()
+    with pytest.raises(SystemExit) as exc:
+        create_admin(mock_session, email="invalid-email", password="validpassword123")
+    assert exc.value.code == 1
+    mock_session.add.assert_not_called()
+
+
+def test_create_admin_short_password():
+    mock_session = MagicMock()
+    with pytest.raises(SystemExit) as exc:
+        create_admin(mock_session, email="admin@example.com", password="short")
+    assert exc.value.code == 1
+    mock_session.add.assert_not_called()
+
+
+def test_create_admin_duplicate_email():
+    mock_session = MagicMock()
+    existing_user = models.User(id=1, email="admin@example.com")
+    mock_session.query.return_value.filter.return_value.first.return_value = (
+        existing_user
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        create_admin(
+            mock_session, email="admin@example.com", password="validpassword123"
+        )
+    assert exc.value.code == 1
+    mock_session.add.assert_not_called()
+
+
+def test_promote_user_success():
+    mock_session = MagicMock()
+    target_user = models.User(
+        id=2, email="user@example.com", role="user", is_active=True
+    )
+    mock_session.query.return_value.filter.return_value.first.return_value = target_user
+
+    promote_user(mock_session, email="user@example.com", role="organizer")
+
+    assert target_user.role == "organizer"
+    mock_session.commit.assert_called_once()
+    mock_session.refresh.assert_called_once_with(target_user)
+
+
+def test_promote_user_not_found():
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(SystemExit) as exc:
+        promote_user(mock_session, email="missing@example.com", role="admin")
+    assert exc.value.code == 1
+
+
+def test_promote_user_invalid_role():
+    mock_session = MagicMock()
+    target_user = models.User(
+        id=3, email="user@example.com", role="user", is_active=True
+    )
+    mock_session.query.return_value.filter.return_value.first.return_value = target_user
+
+    with pytest.raises(SystemExit) as exc:
+        promote_user(mock_session, email="user@example.com", role="superhero")
+    assert exc.value.code == 1
+
+
+def test_promote_user_guard_cannot_demote_last_admin():
+    mock_session = MagicMock()
+    admin_user = models.User(
+        id=1, email="admin@example.com", role="admin", is_active=True
+    )
+
+    filter_mock = MagicMock()
+    # First call: find user by email -> admin_user
+    # Second call: count active admins -> 1
+    filter_mock.first.return_value = admin_user
+    filter_mock.count.return_value = 1
+    mock_session.query.return_value.filter.return_value = filter_mock
+
+    with pytest.raises(SystemExit) as exc:
+        promote_user(mock_session, email="admin@example.com", role="organizer")
+    assert exc.value.code == 1
+
+
+def test_promote_user_demote_admin_allowed_with_multiple_admins():
+    mock_session = MagicMock()
+    admin_user = models.User(
+        id=1, email="admin@example.com", role="admin", is_active=True
+    )
+
+    filter_mock = MagicMock()
+    filter_mock.first.return_value = admin_user
+    filter_mock.count.return_value = 2
+    mock_session.query.return_value.filter.return_value = filter_mock
+
+    promote_user(mock_session, email="admin@example.com", role="organizer")
+    assert admin_user.role == "organizer"
+    mock_session.commit.assert_called_once()
+
+
+def test_list_users_empty(capsys):
+    mock_session = MagicMock()
+    mock_session.query.return_value.order_by.return_value.all.return_value = []
+
+    list_users(mock_session)
+    captured = capsys.readouterr()
+    assert "No users found." in captured.out
+
+
+def test_list_users_populated(capsys):
+    mock_session = MagicMock()
+    user1 = models.User(id=1, email="first@example.com", role="admin", is_active=True)
+    user2 = models.User(id=2, email="second@example.com", role="user", is_active=False)
+    mock_session.query.return_value.order_by.return_value.all.return_value = [
+        user1,
+        user2,
+    ]
+
+    list_users(mock_session)
+    captured = capsys.readouterr()
+    assert "first@example.com" in captured.out
+    assert "admin" in captured.out
+    assert "second@example.com" in captured.out
+    assert "False" in captured.out
+
+
+@patch("app.cli.create_admin")
+@patch("app.cli.SessionLocal")
+def test_cli_main_create_admin(mock_session_local, mock_create_admin):
+    test_args = [
+        "veditor",
+        "admin",
+        "create-admin",
+        "--email",
+        "admin@example.com",
+        "--password",
+        "pass123456",
+    ]
+    with patch.object(sys, "argv", test_args):
+        main()
+
+    mock_session_local.assert_called_once()
+    mock_create_admin.assert_called_once_with(
+        mock_session_local.return_value, "admin@example.com", "pass123456"
+    )
+    mock_session_local.return_value.close.assert_called_once()
+
+
+@patch("app.cli.promote_user")
+@patch("app.cli.SessionLocal")
+def test_cli_main_promote_user(mock_session_local, mock_promote_user):
+    test_args = [
+        "veditor",
+        "admin",
+        "promote-user",
+        "--email",
+        "user@example.com",
+        "--role",
+        "organizer",
+    ]
+    with patch.object(sys, "argv", test_args):
+        main()
+
+    mock_session_local.assert_called_once()
+    mock_promote_user.assert_called_once_with(
+        mock_session_local.return_value, "user@example.com", "organizer"
+    )
+    mock_session_local.return_value.close.assert_called_once()
+
+
+@patch("app.cli.list_users")
+@patch("app.cli.SessionLocal")
+def test_cli_main_list_users(mock_session_local, mock_list_users):
+    test_args = ["veditor", "admin", "list-users"]
+    with patch.object(sys, "argv", test_args):
+        main()
+
+    mock_session_local.assert_called_once()
+    mock_list_users.assert_called_once_with(mock_session_local.return_value)
     mock_session_local.return_value.close.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,9 +195,12 @@ def test_promote_user_guard_cannot_demote_last_admin():
 
     filter_mock = MagicMock()
     # First call: find user by email -> admin_user
-    # Second call: count active admins -> 1
+    # Second call: active admins query -> [(1,)]
     filter_mock.first.return_value = admin_user
     filter_mock.count.return_value = 1
+    filter_mock.order_by.return_value.with_for_update.return_value.all.return_value = [
+        (1,)
+    ]
     mock_session.query.return_value.filter.return_value = filter_mock
 
     with pytest.raises(SystemExit) as exc:
@@ -214,6 +217,10 @@ def test_promote_user_demote_admin_allowed_with_multiple_admins():
     filter_mock = MagicMock()
     filter_mock.first.return_value = admin_user
     filter_mock.count.return_value = 2
+    filter_mock.order_by.return_value.with_for_update.return_value.all.return_value = [
+        (1,),
+        (2,),
+    ]
     mock_session.query.return_value.filter.return_value = filter_mock
 
     promote_user(mock_session, email="admin@example.com", role="organizer")
@@ -247,19 +254,21 @@ def test_list_users_populated(capsys):
     assert "False" in captured.out
 
 
+@patch("getpass.getpass", return_value="pass123456")
 @patch("app.cli.create_admin")
 @patch("app.cli.SessionLocal")
-def test_cli_main_create_admin(mock_session_local, mock_create_admin):
+def test_cli_main_create_admin(mock_session_local, mock_create_admin, mock_getpass):
     test_args = [
         "veditor",
         "admin",
         "create-admin",
         "--email",
         "admin@example.com",
-        "--password",
-        "pass123456",
     ]
-    with patch.object(sys, "argv", test_args):
+    with (
+        patch.object(sys, "argv", test_args),
+        patch("sys.stdin.isatty", return_value=True),
+    ):
         main()
 
     mock_session_local.assert_called_once()
@@ -267,6 +276,27 @@ def test_cli_main_create_admin(mock_session_local, mock_create_admin):
         mock_session_local.return_value, "admin@example.com", "pass123456"
     )
     mock_session_local.return_value.close.assert_called_once()
+
+
+@patch("app.cli.create_admin")
+@patch("app.cli.SessionLocal")
+def test_cli_main_create_admin_piped_stdin(mock_session_local, mock_create_admin):
+    import io
+
+    test_args = [
+        "veditor",
+        "admin",
+        "create-admin",
+        "--email",
+        "admin@example.com",
+    ]
+    fake_stdin = io.StringIO("pipedpassword123\n")
+    with patch.object(sys, "argv", test_args), patch("sys.stdin", fake_stdin):
+        main()
+
+    mock_create_admin.assert_called_once_with(
+        mock_session_local.return_value, "admin@example.com", "pipedpassword123"
+    )
 
 
 @patch("app.cli.promote_user")

--- a/tests/test_pipeline_auth_integration.py
+++ b/tests/test_pipeline_auth_integration.py
@@ -1,0 +1,391 @@
+from datetime import UTC, datetime, timedelta
+from typing import Annotated
+
+import pytest
+from fastapi import Depends
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app import models
+from app.auth import hash_api_key, require_event_access
+from app.cli import create_admin
+from app.db import Base, SessionLocal, engine, get_db
+from app.main import app
+from app.security import create_access_token, create_session_token, hash_password
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def db_session():
+    db = SessionLocal()
+    app.dependency_overrides[get_db] = lambda: db
+    created = []
+    orig_add = db.add
+
+    def track_add(instance):
+        created.append(instance)
+        return orig_add(instance)
+
+    db.add = track_add
+    try:
+        yield db
+    finally:
+        try:
+            db.rollback()
+            for obj in reversed(created):
+                try:
+                    db.delete(obj)
+                    db.commit()
+                except Exception:  # noqa: BLE001
+                    db.rollback()
+            try:
+                db.query(models.Review).filter(
+                    models.Review.talk.has(
+                        models.Talk.event.has(models.Event.name.like("%Pipeline%"))
+                    )
+                ).delete(synchronize_session=False)
+                db.query(models.Talk).filter(
+                    models.Talk.event.has(models.Event.name.like("%Pipeline%"))
+                ).delete(synchronize_session=False)
+                db.query(models.Event).filter(
+                    models.Event.name.like("%Pipeline%")
+                ).delete(synchronize_session=False)
+                db.query(models.Client).filter(
+                    models.Client.hashed_key == hash_api_key("scoped-pipeline-api-key")
+                ).delete(synchronize_session=False)
+                db.query(models.User).filter(
+                    models.User.email.like("%@pipeline-test.com")
+                ).delete(synchronize_session=False)
+                db.query(models.User).filter(
+                    models.User.email == "root_admin@test.com"
+                ).delete(synchronize_session=False)
+                db.commit()
+            except Exception:  # noqa: BLE001
+                db.rollback()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            db.close()
+
+
+# Mount event endpoint using require_event_access dependency for integration gating
+if not any(
+    getattr(route, "path", None) == "/events/{event_id}" for route in app.routes
+):
+
+    @app.get("/events/{event_id}")
+    def get_event_endpoint(
+        event: Annotated[models.Event, Depends(require_event_access())],
+    ):
+        return {
+            "id": event.id,
+            "name": event.name,
+            "created_by_user_id": event.created_by_user_id,
+        }
+
+
+def test_complete_user_lifecycle_and_pipeline_auth(
+    client: TestClient, db_session: Session
+):
+    """
+    End-to-end integration test covering complete user lifecycle and pipeline authentication/authorization:
+    a) Public registration: POST /signup creates user with role="user"
+    b) Initial admin assignment: Provision admin via create_admin
+    c) Admin lists users via GET /admin/users
+    d) Role elevation: Admin calls POST /admin/users/{user1.id}/promote with role="organizer"
+    e) Event & talk creation: Organizer 1 creates an event and a talk (Event.created_by_user_id == user1.id)
+    f) Permission denial boundaries:
+       - Unauthenticated request returns 401
+       - Organizer 2 (different organizer) is denied access (403 Forbidden)
+       - Regular user is denied access (403 Forbidden)
+       - Admin has unconditional access (200 OK)
+       - Scoped API key client access: in-scope event returns 200, out-of-scope event returns 403
+    g) Review attribution: models.Review with talk_id and user_id, verified in DB
+    h) Invalidation: Admin deactivates Organizer 1, pre-existing cookies and bearer tokens rejected (401)
+    """
+    # -------------------------------------------------------------------------
+    # a) Public registration: POST /signup creates user with role="user"
+    # -------------------------------------------------------------------------
+    signup_resp = client.post(
+        "/signup",
+        data={
+            "email": "user1@pipeline-test.com",
+            "password": "User1Password123!",
+            "password_confirm": "User1Password123!",
+        },
+        follow_redirects=False,
+    )
+    assert signup_resp.status_code == 303
+    client.cookies.clear()
+
+    user1 = (
+        db_session.query(models.User)
+        .filter(models.User.email == "user1@pipeline-test.com")
+        .first()
+    )
+    assert user1 is not None
+    assert user1.email == "user1@pipeline-test.com"
+    assert user1.role == "user"
+    assert user1.is_active is True
+
+    # -------------------------------------------------------------------------
+    # b) Initial admin assignment: Provision admin via create_admin
+    # -------------------------------------------------------------------------
+    create_admin(db_session, "root_admin@test.com", "SecretPass123!")
+    admin = (
+        db_session.query(models.User)
+        .filter(models.User.email == "root_admin@test.com")
+        .first()
+    )
+    assert admin is not None
+    assert admin.email == "root_admin@test.com"
+    assert admin.role == "admin"
+    assert admin.is_active is True
+
+    # -------------------------------------------------------------------------
+    # c) Admin lists users via GET /admin/users
+    # -------------------------------------------------------------------------
+    admin_token = create_session_token(admin.id, admin.role)
+    client.cookies.set("veditor_session", admin_token)
+    list_resp = client.get("/admin/users")
+    client.cookies.clear()
+
+    assert list_resp.status_code == 200
+    users_data = list_resp.json()
+    emails = [u["email"] for u in users_data]
+    assert "root_admin@test.com" in emails
+    assert "user1@pipeline-test.com" in emails
+
+    # -------------------------------------------------------------------------
+    # d) Role elevation: Admin calls POST /admin/users/{user1.id}/promote with role="organizer"
+    # -------------------------------------------------------------------------
+    client.cookies.set("veditor_session", admin_token)
+    promote_resp = client.post(
+        f"/admin/users/{user1.id}/promote",
+        json={"role": "organizer"},
+    )
+    client.cookies.clear()
+
+    assert promote_resp.status_code == 200
+    assert promote_resp.json()["role"] == "organizer"
+    db_session.refresh(user1)
+    assert user1.role == "organizer"
+
+    # -------------------------------------------------------------------------
+    # e) Event & talk creation: Organizer 1 creates an event and a talk
+    # -------------------------------------------------------------------------
+    event1 = models.Event(
+        name="Pipeline Test Event 1",
+        created_by_user_id=user1.id,
+    )
+    db_session.add(event1)
+    db_session.commit()
+    db_session.refresh(event1)
+
+    assert event1.created_by_user_id == user1.id
+    assert event1.created_by_user == user1
+    assert event1 in user1.events
+
+    now = datetime.now(UTC)
+    talk1 = models.Talk(
+        event_id=event1.id,
+        title="Pipeline Test Talk 1",
+        room="Auditorium A",
+        start=now,
+        end=now + timedelta(hours=1),
+        status="preview",
+    )
+    db_session.add(talk1)
+    db_session.commit()
+    db_session.refresh(talk1)
+
+    assert talk1.id is not None
+    assert talk1.event_id == event1.id
+    assert talk1.event == event1
+
+    # -------------------------------------------------------------------------
+    # f) Permission denial boundaries:
+    # -------------------------------------------------------------------------
+    # 1. Unauthenticated request to event/talk endpoint returns 401
+    res_unauth = client.get(f"/events/{event1.id}")
+    assert res_unauth.status_code == 401
+    assert res_unauth.headers.get("www-authenticate") == "Bearer"
+
+    # Organizer 1 (creator) has access with cookie and bearer token
+    org1_cookie = create_session_token(user1.id, user1.role)
+    client.cookies.set("veditor_session", org1_cookie)
+    res_org1_cookie = client.get(f"/events/{event1.id}")
+    client.cookies.clear()
+    assert res_org1_cookie.status_code == 200
+    assert res_org1_cookie.json()["id"] == event1.id
+    assert res_org1_cookie.json()["created_by_user_id"] == user1.id
+
+    org1_bearer = create_access_token(user1.id, user1.email, user1.role)
+    res_org1_bearer = client.get(
+        f"/events/{event1.id}", headers={"Authorization": f"Bearer {org1_bearer}"}
+    )
+    assert res_org1_bearer.status_code == 200
+    assert res_org1_bearer.json()["id"] == event1.id
+
+    # 2. Organizer 2 (different organizer) is denied access (403 Forbidden) to Organizer 1's event
+    org2 = models.User(
+        email="org2@pipeline-test.com",
+        hashed_password=hash_password("Pass12345!"),
+        role="organizer",
+        is_active=True,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(org2)
+    db_session.commit()
+    db_session.refresh(org2)
+
+    org2_cookie = create_session_token(org2.id, org2.role)
+    client.cookies.set("veditor_session", org2_cookie)
+    res_org2_cookie = client.get(f"/events/{event1.id}")
+    client.cookies.clear()
+    assert res_org2_cookie.status_code == 403
+    assert (
+        res_org2_cookie.json()["detail"]
+        == "User is not authorized to access this event"
+    )
+
+    org2_bearer = create_access_token(org2.id, org2.email, org2.role)
+    res_org2_bearer = client.get(
+        f"/events/{event1.id}", headers={"Authorization": f"Bearer {org2_bearer}"}
+    )
+    assert res_org2_bearer.status_code == 403
+    assert (
+        res_org2_bearer.json()["detail"]
+        == "User is not authorized to access this event"
+    )
+
+    # 3. Regular user is denied access (403 Forbidden)
+    regular_user = models.User(
+        email="regular@pipeline-test.com",
+        hashed_password=hash_password("Pass12345!"),
+        role="user",
+        is_active=True,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(regular_user)
+    db_session.commit()
+    db_session.refresh(regular_user)
+
+    reg_cookie = create_session_token(regular_user.id, regular_user.role)
+    client.cookies.set("veditor_session", reg_cookie)
+    res_reg_cookie = client.get(f"/events/{event1.id}")
+    client.cookies.clear()
+    assert res_reg_cookie.status_code == 403
+    assert (
+        res_reg_cookie.json()["detail"] == "User is not authorized to access this event"
+    )
+
+    reg_bearer = create_access_token(
+        regular_user.id, regular_user.email, regular_user.role
+    )
+    res_reg_bearer = client.get(
+        f"/events/{event1.id}", headers={"Authorization": f"Bearer {reg_bearer}"}
+    )
+    assert res_reg_bearer.status_code == 403
+    assert (
+        res_reg_bearer.json()["detail"] == "User is not authorized to access this event"
+    )
+
+    # 4. Admin has unconditional access (200 OK)
+    client.cookies.set("veditor_session", admin_token)
+    res_admin_cookie = client.get(f"/events/{event1.id}")
+    client.cookies.clear()
+    assert res_admin_cookie.status_code == 200
+    assert res_admin_cookie.json()["id"] == event1.id
+
+    admin_bearer = create_access_token(admin.id, admin.email, admin.role)
+    res_admin_bearer = client.get(
+        f"/events/{event1.id}", headers={"Authorization": f"Bearer {admin_bearer}"}
+    )
+    assert res_admin_bearer.status_code == 200
+
+    # 5. Scoped API key client access: in-scope event returns 200, out-of-scope event returns 403
+    api_key_scoped = "scoped-pipeline-api-key"
+    client_scoped = models.Client(
+        hashed_key=hash_api_key(api_key_scoped),
+        event_ids=[event1.id],
+    )
+    db_session.add(client_scoped)
+
+    event2 = models.Event(
+        name="Pipeline Test Event 2",
+        created_by_user_id=org2.id,
+    )
+    db_session.add(event2)
+    db_session.commit()
+    db_session.refresh(client_scoped)
+    db_session.refresh(event2)
+
+    # In-scope event returns 200
+    res_scoped_in = client.get(
+        f"/events/{event1.id}", headers={"X-API-Key": api_key_scoped}
+    )
+    assert res_scoped_in.status_code == 200
+    assert res_scoped_in.json()["id"] == event1.id
+
+    # Out-of-scope event returns 403
+    res_scoped_out = client.get(
+        f"/events/{event2.id}", headers={"X-API-Key": api_key_scoped}
+    )
+    assert res_scoped_out.status_code == 403
+    assert (
+        res_scoped_out.json()["detail"]
+        == "Client is not authorized to access this event"
+    )
+
+    # -------------------------------------------------------------------------
+    # g) Review attribution:
+    # -------------------------------------------------------------------------
+    review = models.Review(
+        talk_id=talk1.id,
+        decision="approve",
+        user_id=user1.id,
+    )
+    db_session.add(review)
+    db_session.commit()
+    db_session.refresh(review)
+
+    assert review.user_id == user1.id
+    assert review.user is not None
+    assert review.user.email == user1.email
+    assert review in user1.reviews
+
+    # -------------------------------------------------------------------------
+    # h) Invalidation:
+    # -------------------------------------------------------------------------
+    # Admin deactivates Organizer 1
+    client.cookies.set("veditor_session", admin_token)
+    deact_resp = client.post(f"/admin/users/{user1.id}/deactivate")
+    client.cookies.clear()
+
+    assert deact_resp.status_code == 200
+    assert deact_resp.json()["is_active"] is False
+    db_session.refresh(user1)
+    assert user1.is_active is False
+
+    # Pre-existing cookies and bearer tokens for Organizer 1 are immediately rejected (401)
+    client.cookies.set("veditor_session", org1_cookie)
+    res_deact_cookie = client.get(f"/events/{event1.id}")
+    client.cookies.clear()
+    assert res_deact_cookie.status_code == 401
+    assert res_deact_cookie.json()["detail"] == "User account not found or inactive"
+
+    res_deact_bearer = client.get(
+        f"/events/{event1.id}", headers={"Authorization": f"Bearer {org1_bearer}"}
+    )
+    assert res_deact_bearer.status_code == 401
+    assert res_deact_bearer.json()["detail"] == "User account not found or inactive"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,6 +12,7 @@ from app.security import (
     decode_session_token,
     get_session_secret,
     hash_password,
+    is_valid_email,
     verify_password,
 )
 
@@ -324,3 +325,26 @@ def test_decode_rejects_unallowed_algorithm():
     )
     assert decode_session_token(fake_token) is None
     assert decode_access_token(fake_token) is None
+
+
+def test_is_valid_email():
+    # Valid RFC 5322 emails
+    assert is_valid_email("user@example.com") is True
+    assert is_valid_email("user.name+tag@sub.domain.co") is True
+    assert is_valid_email("admin@test.org") is True
+    assert is_valid_email('  "quoted name"@domain.com  ') is True
+
+    # Invalid emails
+    assert is_valid_email("") is False
+    assert is_valid_email(None) is False
+    assert is_valid_email(12345) is False
+    assert is_valid_email("invalid-email") is False
+    assert is_valid_email("@missinguser.com") is False
+    assert is_valid_email("missingdomain@") is False
+    assert is_valid_email("spaces in@domain.com") is False
+    assert is_valid_email("user@domain") is False
+    assert is_valid_email("user@.com") is False
+    assert is_valid_email("user@domain.") is False
+    assert is_valid_email("user@example..com") is False
+    assert is_valid_email("a@b@c.com") is False
+    assert is_valid_email("<script>@domain.com") is False

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -333,6 +333,8 @@ def test_is_valid_email():
     assert is_valid_email("user.name+tag@sub.domain.co") is True
     assert is_valid_email("admin@test.org") is True
     assert is_valid_email('  "quoted name"@domain.com  ') is True
+    assert is_valid_email("user@localhost") is True
+    assert is_valid_email("user@[IPv6:2001:db8::1]") is True
 
     # Invalid emails
     assert is_valid_email("") is False
@@ -342,7 +344,6 @@ def test_is_valid_email():
     assert is_valid_email("@missinguser.com") is False
     assert is_valid_email("missingdomain@") is False
     assert is_valid_email("spaces in@domain.com") is False
-    assert is_valid_email("user@domain") is False
     assert is_valid_email("user@.com") is False
     assert is_valid_email("user@domain.") is False
     assert is_valid_email("user@example..com") is False


### PR DESCRIPTION
## Closes #214 

>[!NOTE]
> - This is draft stacked pr and will ready to review after #220 & #221 is merged

Implements administrative user management endpoints, operational CLI commands for database provisioning and role administration, standard library RFC 5322 email validation, and an automated test suite verifying all authentication, authorization, lifecycle, and pipeline integration flows.

---

### Key Changes

1. **Administrative API Endpoints** ([`app/routes/admin.py`](file:///Users/virus/Developer/fossasia-new/veditor/app/routes/admin.py)):
   - Protected router at `/admin` requiring `admin` role (`require_role('admin')`).
   - `GET /admin/users`: Paginated listing of registered users (`skip`, `limit`) returning [`UserRead`](file:///Users/virus/Developer/fossasia-new/veditor/app/schemas.py) instances ordered by user ID.
   - `POST /admin/users/{id}/promote`: Elevates or demotes user role (`"user"`, `"organizer"`, `"admin"`). Includes row-level locking (`with_for_update()`) preventing demotions that would leave zero active administrators.
   - `POST /admin/users/{id}/deactivate`: Deactivates accounts (`is_active = False`). Prohibits self-deactivation and deactivating the last active administrator. Automatically revokes all existing sessions and tokens on subsequent calls.

2. **Operational CLI Commands** ([`app/cli.py`](file:///Users/virus/Developer/fossasia-new/veditor/app/cli.py)):
   - `veditor admin create-admin`: Directly provisions an active administrator with Argon2id password hashing as a disaster recovery and bootstrap mechanism.
   - `veditor admin promote-user`: Direct terminal role modification with last-admin demotion safeguards.
   - `veditor admin list-users`: Clean, aligned tabular summary of all registered users.

3. **Standard Library Email Validation** ([`app/security.py`](file:///Users/virus/Developer/fossasia-new/veditor/app/security.py)):
   - Replaced duplicated, naive regex pattern (`r"^[^@\s]+@[^@\s]+\.[^@\s]+$"`) with [`is_valid_email()`](file:///Users/virus/Developer/fossasia-new/veditor/app/security.py) using Python's standard library `email.headerregistry.Address` (RFC 5322 compliant, zero third-party dependencies).

4. **Comprehensive Test Suite**:
   - [`tests/test_admin_routes.py`](file:///Users/virus/Developer/fossasia-new/veditor/tests/test_admin_routes.py): 15 integration tests covering authorization boundaries (401/403), user listing pagination, promotion, self-deactivation prevention (400), last-admin lockout guards, and immediate session/token invalidation upon deactivation.
   - [`tests/test_cli.py`](file:///Users/virus/Developer/fossasia-new/veditor/tests/test_cli.py): 20 tests verifying CLI functions, validation logic, and CLI argument parsing.
   - [`tests/test_pipeline_auth_integration.py`](file:///Users/virus/Developer/fossasia-new/veditor/tests/test_pipeline_auth_integration.py): Full user lifecycle test covering public registration, admin provisioning, promotion, event/talk creation, permission denial boundaries, review attribution, and deactivation.
   - [`tests/test_security.py`](file:///Users/virus/Developer/fossasia-new/veditor/tests/test_security.py): Unit tests for RFC 5322 email validation.

---

### Command Usage Guide

#### 1. CLI Commands

##### A. List All Registered Users
```bash
# Native uv run
uv run veditor admin list-users

# If installed in active venv
veditor admin list-users

# Output format:
# ID     Email                            Role         Active   Created At
# ------------------------------------------------------------------------
# 1      admin@example.com                admin        True     2026-09-11 12:00:00
# 2      organizer@example.com            organizer    True     2026-09-11 12:15:00
```

##### B. Create an Administrator Account (Bootstrap / Disaster Recovery)
```bash
uv run veditor admin create-admin \
  --email "admin@example.com" \
  --password "SuperSecurePass123"

# Output:
# Created admin user 'admin@example.com' with ID 1
```

##### C. Promote or Demote a User Role
```bash
# Promote to organizer
uv run veditor admin promote-user \
  --email "user@example.com" \
  --role "organizer"

# Promote to admin
uv run veditor admin promote-user \
  --email "user@example.com" \
  --role "admin"

# Demote to user
uv run veditor admin promote-user \
  --email "user@example.com" \
  --role "user"
```

##### D. Create Machine API Key Scoped to Event (Pre-existing Command)
```bash
uv run veditor admin create-client --event-name "FOSSASIA 2026"
# or for an existing event:
uv run veditor admin create-client --event-id 1
```

---

#### 2. HTTP Admin API Endpoints

All endpoints require an authenticated administrator account via session cookie (`veditor_session`), Bearer token (`Authorization: Bearer <JWT>`), or administrative API key (`X-API-Key`). Non-admins receive `403 Forbidden`; unauthenticated callers receive `401 Unauthorized`.

##### A. List Registered Users
```bash
curl -X GET "http://localhost:8000/admin/users?skip=0&limit=50" \
  -H "Authorization: Bearer <ADMIN_JWT_TOKEN>"
```

Response:
```json
[
  {
    "id": 1,
    "email": "admin@example.com",
    "role": "admin",
    "is_active": true,
    "created_at": "2026-09-11T12:00:00Z"
  },
  {
    "id": 2,
    "email": "organizer@example.com",
    "role": "organizer",
    "is_active": true,
    "created_at": "2026-09-11T12:15:00Z"
  }
]
```

##### B. Promote / Demote User Role
```bash
curl -X POST "http://localhost:8000/admin/users/2/promote" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <ADMIN_JWT_TOKEN>" \
  -d '{"role": "organizer"}'
```

Response:
```json
{
  "id": 2,
  "email": "organizer@example.com",
  "role": "organizer",
  "is_active": true,
  "created_at": "2026-09-11T12:15:00Z"
}
```

##### C. Deactivate User Account
```bash
curl -X POST "http://localhost:8000/admin/users/2/deactivate" \
  -H "Authorization: Bearer <ADMIN_JWT_TOKEN>"
```

Response:
```json
{
  "id": 2,
  "email": "organizer@example.com",
  "role": "organizer",
  "is_active": false,
  "created_at": "2026-09-11T12:15:00Z"
}
```

*Note: Once deactivated, any subsequent request from that user via pre-existing session cookies or JWT access tokens immediately returns `401 Unauthorized` ("User account not found or inactive"), and login attempts via `POST /login` return `400 Bad Request`.*

---

### Verification

```bash
# Run full automated test suite (512 tests)
uv run pytest --ignore=tests/test_smoke.py

# Run admin, CLI, and lifecycle integration tests
uv run pytest tests/test_admin_routes.py tests/test_cli.py tests/test_pipeline_auth_integration.py -v

# Run AST storage boundary and pipeline purity checks
uv run pytest tests/test_storage_boundary.py tests/test_pipeline_imports.py
```
```

## Summary by Sourcery

Provide secure administrator user management across the API and CLI, with stronger email validation and comprehensive lifecycle authorization coverage.

New Features:
- Add administrator-only API endpoints for listing users, changing roles, and deactivating accounts.
- Add CLI commands for bootstrapping administrators, managing user roles, and listing users.

Bug Fixes:
- Prevent administrative actions from removing the last active administrator and reject self-deactivation.
- Ensure deactivated users lose access through existing sessions and tokens.

Enhancements:
- Replace signup email regex validation with standard-library RFC 5322 validation.
- Restrict administrative API access to human administrator sessions rather than machine API keys.

Tests:
- Add coverage for administrator authorization, user lifecycle operations, CLI behavior, email validation, concurrency safeguards, and end-to-end authentication and authorization flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added administrator user management through the CLI and API.
  - Administrators can list users, create administrators, promote accounts, and deactivate accounts.
  - Added pagination, role and email validation, and safeguards against removing the last active administrator.
  - Deactivated accounts are immediately denied access.
  - Administrator passwords can be entered securely through interactive or piped input.

- **Bug Fixes**
  - Standardized email validation across authentication and administration workflows.
  - Restricted administration actions to human administrator sessions.

- **Tests**
  - Added coverage for administration, authentication, authorization, and user lifecycle workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->