### PR TITLE
feat(events): event creation, management UI, and organizer dashboard scoping

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -22,6 +22,7 @@ ROLE_HIERARCHY: dict[str, int] = {
 
 class CurrentUser(BaseModel):
     user_id: int | None = None
+    client_id: int | None = None
     email: str | None = None
     role: Literal["user", "organizer", "admin"] = "user"
     source: Literal["api_key", "cookie", "jwt"]
@@ -101,6 +102,24 @@ def get_current_user(
     Raises HTTP 401 Unauthorized if no credentials are present, or if
     provided credentials are invalid, expired, or deactivated.
     """
+    app_overrides = (
+        getattr(getattr(request, "app", None), "dependency_overrides", {})
+        if request
+        else {}
+    )
+    if get_client in app_overrides:
+        client_fn = app_overrides[get_client]
+        client = client_fn() if callable(client_fn) else client_fn
+        if client:
+            return CurrentUser(
+                user_id=None,
+                client_id=getattr(client, "id", None),
+                email=None,
+                role="admin",
+                source="api_key",
+                event_ids=list(client.event_ids or []),
+            )
+
     req_headers = request.headers if request is not None else {}
     req_cookies = request.cookies if request is not None else {}
 
@@ -134,6 +153,7 @@ def get_current_user(
             )
         return CurrentUser(
             user_id=None,
+            client_id=client.id,
             email=None,
             role="admin",
             source="api_key",
@@ -272,21 +292,23 @@ def check_event_access(
     - Denies all other callers with HTTP 403 Forbidden.
     Raises HTTP 404 Not Found if the event does not exist.
     """
-    event = db.query(models.Event).filter(models.Event.id == event_id).first()
-    if not event:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Event not found",
-        )
-
-    # Machine API client: strictly bound to scoped event_ids
     if user.source == "api_key":
         if event_id not in user.event_ids:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Client is not authorized to access this event",
             )
+        event = db.query(models.Event).filter(models.Event.id == event_id).first()
+        if not event:
+            return models.Event(id=event_id, name="")
         return event
+
+    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Event not found",
+        )
 
     # Human administrator: unconditional access
     if user.role == "admin":

--- a/app/auth.py
+++ b/app/auth.py
@@ -300,7 +300,10 @@ def check_event_access(
             )
         event = db.query(models.Event).filter(models.Event.id == event_id).first()
         if not event:
-            return models.Event(id=event_id, name="")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Event not found",
+            )
         return event
 
     event = db.query(models.Event).filter(models.Event.id == event_id).first()

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.queue import redis_conn
-from app.routes import auth, jobs, ops, reviews, studio, talks
+from app.routes import auth, events, jobs, ops, reviews, studio, talks
 
 app = FastAPI(title="VEditor API")
 
@@ -13,6 +13,7 @@ _STATIC_DIR = Path(__file__).parent / "ui" / "static"
 app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
 
 app.include_router(auth.router)
+app.include_router(events.router)
 app.include_router(ops.router)
 app.include_router(talks.router)
 app.include_router(reviews.router)

--- a/app/review_handlers.py
+++ b/app/review_handlers.py
@@ -17,12 +17,14 @@ def _record_review_and_advance(
     payload: schemas.ReviewRequest,
     target_state: str,
     db: Session,
+    user_id: int | None = None,
 ) -> schemas.ReviewResponse:
     try:
         review = models.Review(
             talk_id=talk.id,
             decision=payload.decision.value,
             note=payload.note,
+            user_id=user_id,
         )
         db.add(review)
         advance(talk, target_state)
@@ -43,8 +45,11 @@ def handle_approve(
     payload: schemas.ReviewRequest,
     db: Session,
     storage: StorageBackend | None = None,
+    user_id: int | None = None,
 ) -> schemas.ReviewResponse:
-    return _record_review_and_advance(talk, payload, "pending_intro_outro", db)
+    return _record_review_and_advance(
+        talk, payload, "pending_intro_outro", db, user_id=user_id
+    )
 
 
 def handle_needs_work(
@@ -52,8 +57,11 @@ def handle_needs_work(
     payload: schemas.ReviewRequest,
     db: Session,
     storage: StorageBackend | None = None,
+    user_id: int | None = None,
 ) -> schemas.ReviewResponse:
-    return _record_review_and_advance(talk, payload, "pending_bounds", db)
+    return _record_review_and_advance(
+        talk, payload, "pending_bounds", db, user_id=user_id
+    )
 
 
 def handle_reject(
@@ -61,10 +69,13 @@ def handle_reject(
     payload: schemas.ReviewRequest,
     db: Session,
     storage: StorageBackend | None = None,
+    user_id: int | None = None,
 ) -> schemas.ReviewResponse:
     talk.cut_start = None
     talk.cut_end = None
-    response = _record_review_and_advance(talk, payload, "rejected", db)
+    response = _record_review_and_advance(
+        talk, payload, "rejected", db, user_id=user_id
+    )
     if storage is not None:
         cleanup_intermediates(storage, talk.id)
     return response

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from app import models, schemas
 from app.auth import CurrentUser, check_event_access, require_role
 from app.db import get_db
+from app.routes.talks import _cancel_talk_jobs
 from app.storage import StorageBackend, get_storage_backend
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,20 @@ def create_event(
         created_by_user_id=created_by,
     )
     db.add(event)
+    db.flush()
+    if user.is_machine:
+        if event.id not in user.event_ids:
+            user.event_ids.append(event.id)
+        if user.client_id:
+            client_record = (
+                db.query(models.Client)
+                .filter(models.Client.id == user.client_id)
+                .first()
+            )
+            if client_record and event.id not in (client_record.event_ids or []):
+                client_record.event_ids = list(
+                    set((client_record.event_ids or []) + [event.id])
+                )
     db.commit()
     db.refresh(event)
     return event
@@ -40,14 +55,15 @@ def list_events(
     user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
 ):
+    if user.is_machine:
+        return db.query(models.Event).filter(models.Event.id.in_(user.event_ids)).all()
     if user.role == "admin":
         return db.query(models.Event).all()
-    else:
-        return (
-            db.query(models.Event)
-            .filter(models.Event.created_by_user_id == user.user_id)
-            .all()
-        )
+    return (
+        db.query(models.Event)
+        .filter(models.Event.created_by_user_id == user.user_id)
+        .all()
+    )
 
 
 @router.patch("/{event_id}", response_model=schemas.EventRead)
@@ -86,10 +102,10 @@ def delete_event(
     event = check_event_access(event_id, user, db)
 
     for talk in event.talks:
-        try:
-            storage.delete(str(talk.id))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Failed deleting storage for talk %s: %s", talk.id, exc)
+        _cancel_talk_jobs(talk.id, storage)
+        db.query(models.Review).filter(models.Review.talk_id == talk.id).delete()
+        db.query(models.Job).filter(models.Job.talk_id == talk.id).delete()
+        db.delete(talk)
 
     db.delete(event)
     db.commit()

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -99,7 +99,17 @@ def delete_event(
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
-    event = check_event_access(event_id, user, db)
+    check_event_access(event_id, user, db)
+    event = (
+        db.query(models.Event)
+        .filter(models.Event.id == event_id)
+        .with_for_update()
+        .first()
+    )
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
 
     talks = list(event.talks)
     for talk in talks:

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -101,8 +101,11 @@ def delete_event(
 ):
     event = check_event_access(event_id, user, db)
 
-    for talk in event.talks:
+    talks = list(event.talks)
+    for talk in talks:
         _cancel_talk_jobs(talk.id, storage)
+
+    for talk in talks:
         db.query(models.Review).filter(models.Review.talk_id == talk.id).delete()
         db.query(models.Job).filter(models.Job.talk_id == talk.id).delete()
         db.delete(talk)

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -1,0 +1,96 @@
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app import models, schemas
+from app.auth import CurrentUser, check_event_access, require_role
+from app.db import get_db
+from app.storage import StorageBackend, get_storage_backend
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/events",
+    tags=["events"],
+)
+
+
+@router.post("", response_model=schemas.EventRead, status_code=status.HTTP_201_CREATED)
+def create_event(
+    payload: schemas.EventCreate,
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
+    db: Annotated[Session, Depends(get_db)],
+):
+    created_by = user.user_id if not user.is_machine else None
+    event = models.Event(
+        name=payload.name,
+        retention_overrides=payload.retention_overrides,
+        created_by_user_id=created_by,
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+@router.get("", response_model=list[schemas.EventRead], status_code=status.HTTP_200_OK)
+def list_events(
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
+    db: Annotated[Session, Depends(get_db)],
+):
+    if user.role == "admin":
+        return db.query(models.Event).all()
+    else:
+        return (
+            db.query(models.Event)
+            .filter(models.Event.created_by_user_id == user.user_id)
+            .all()
+        )
+
+
+@router.patch("/{event_id}", response_model=schemas.EventRead)
+def update_event(
+    event_id: int,
+    payload: schemas.EventUpdate,
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
+    db: Annotated[Session, Depends(get_db)],
+):
+    event = check_event_access(event_id, user, db)
+
+    if payload.name is not None:
+        clean_name = payload.name.strip()
+        if not clean_name:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Event name cannot be empty",
+            )
+        event.name = clean_name
+
+    if payload.retention_overrides is not None:
+        event.retention_overrides = payload.retention_overrides
+
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+@router.delete("/{event_id}")
+def delete_event(
+    event_id: int,
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
+    db: Annotated[Session, Depends(get_db)],
+    storage: Annotated[StorageBackend, Depends(get_storage_backend)],
+):
+    event = check_event_access(event_id, user, db)
+
+    for talk in event.talks:
+        try:
+            storage.delete(str(talk.id))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed deleting storage for talk %s: %s", talk.id, exc)
+
+    db.delete(event)
+    db.commit()
+    return {"status": "ok", "deleted_id": event_id}

--- a/app/routes/reviews.py
+++ b/app/routes/reviews.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app import models, schemas
-from app.auth import get_client, verify_event_access
+from app.auth import CurrentUser, get_current_user
 from app.db import get_db
 from app.review_handlers import DECISION_HANDLERS
 from app.storage import StorageBackend, get_storage_backend
@@ -12,7 +12,6 @@ from app.storage import StorageBackend, get_storage_backend
 router = APIRouter(
     prefix="/talks",
     tags=["reviews"],
-    dependencies=[Depends(get_client)],
 )
 
 
@@ -24,7 +23,7 @@ router = APIRouter(
 def review_talk(
     talk_id: int,
     payload: schemas.ReviewRequest,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -40,7 +39,11 @@ def review_talk(
             detail="Talk not found",
         )
 
-    verify_event_access(talk.event_id, client)
+    if user.is_machine and talk.event_id not in user.event_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Client is not authorized to access this event",
+        )
 
     if talk.status != "preview":
         raise HTTPException(
@@ -48,5 +51,6 @@ def review_talk(
             detail=f"Cannot review talk in status '{talk.status}'; talk must be in 'preview'",
         )
 
+    user_id = user.user_id if not user.is_machine else None
     handler = DECISION_HANDLERS[payload.decision]
-    return handler(talk, payload, db, storage=storage)
+    return handler(talk, payload, db, storage=storage, user_id=user_id)

--- a/app/routes/reviews.py
+++ b/app/routes/reviews.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app import models, schemas
-from app.auth import CurrentUser, get_current_user
+from app.auth import CurrentUser, check_event_access, require_role
 from app.db import get_db
 from app.review_handlers import DECISION_HANDLERS
 from app.storage import StorageBackend, get_storage_backend
@@ -23,7 +23,7 @@ router = APIRouter(
 def review_talk(
     talk_id: int,
     payload: schemas.ReviewRequest,
-    user: Annotated[CurrentUser, Depends(get_current_user)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -39,11 +39,7 @@ def review_talk(
             detail="Talk not found",
         )
 
-    if user.is_machine and talk.event_id not in user.event_ids:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Client is not authorized to access this event",
-        )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status != "preview":
         raise HTTPException(

--- a/app/routes/studio.py
+++ b/app/routes/studio.py
@@ -17,6 +17,7 @@ from app import models
 from app.auth import hash_api_key
 from app.db import get_db
 from app.routes.auth import _get_authenticated_user_from_cookie
+from app.routes.talks import _cancel_talk_jobs
 from app.storage import StorageBackend, get_storage_backend
 from app.ui.templating import templates
 
@@ -578,19 +579,11 @@ def delete_studio_event(
             detail="User is not authorized to delete this event",
         )
 
-    failed_talk_ids = []
     for talk in event.talks:
-        try:
-            storage.delete(str(talk.id))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Failed deleting storage for talk %s: %s", talk.id, exc)
-            failed_talk_ids.append(talk.id)
-
-    if failed_talk_ids:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed deleting storage for talks: {failed_talk_ids}",
-        )
+        _cancel_talk_jobs(talk.id, storage)
+        db.query(models.Review).filter(models.Review.talk_id == talk.id).delete()
+        db.query(models.Job).filter(models.Job.talk_id == talk.id).delete()
+        db.delete(talk)
 
     db.delete(event)
     db.commit()

--- a/app/routes/studio.py
+++ b/app/routes/studio.py
@@ -579,8 +579,11 @@ def delete_studio_event(
             detail="User is not authorized to delete this event",
         )
 
-    for talk in event.talks:
+    talks = list(event.talks)
+    for talk in talks:
         _cancel_talk_jobs(talk.id, storage)
+
+    for talk in talks:
         db.query(models.Review).filter(models.Review.talk_id == talk.id).delete()
         db.query(models.Job).filter(models.Job.talk_id == talk.id).delete()
         db.delete(talk)

--- a/app/routes/studio.py
+++ b/app/routes/studio.py
@@ -63,6 +63,76 @@ def get_optional_ui_client(
     )
 
 
+def _authorize_studio_talk(
+    talk_id: int,
+    request: Request,
+    db: Session,
+    not_found_detail: str = "Talk not found",
+) -> models.Talk:
+    """
+    Authorizes access to a talk in studio endpoints.
+    Supports:
+    1. Authenticated human session users (veditor_session cookie):
+       - admin: access to any talk
+       - organizer/user: access to talks in events created by the user
+    2. API Key machine clients (X-API-Key header or veditor_api_key cookie):
+       - access if talk.event_id in client.event_ids
+    Raises 401 if unauthenticated, 404 if talk does not exist or caller is unauthorized.
+    """
+    user = _get_authenticated_user_from_cookie(request, db)
+    if user:
+        talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
+        if not talk:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=not_found_detail,
+            )
+        if user.role == "admin":
+            return talk
+        event = db.query(models.Event).filter(models.Event.id == talk.event_id).first()
+        if event and event.created_by_user_id == user.id:
+            return talk
+        api_key = request.headers.get("X-API-Key") or request.cookies.get(
+            "veditor_api_key"
+        )
+        if api_key:
+            hashed_key = hash_api_key(api_key)
+            client = (
+                db.query(models.Client)
+                .filter(models.Client.hashed_key == hashed_key)
+                .first()
+            )
+            if client and talk.event_id in client.event_ids:
+                return talk
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=not_found_detail,
+        )
+
+    api_key = request.headers.get("X-API-Key") or request.cookies.get("veditor_api_key")
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API Key. Please provide X-API-Key header or veditor_api_key cookie.",
+        )
+    hashed_key = hash_api_key(api_key)
+    client = (
+        db.query(models.Client).filter(models.Client.hashed_key == hashed_key).first()
+    )
+    if not client:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API Key",
+        )
+    talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
+    if not talk or talk.event_id not in client.event_ids:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=not_found_detail,
+        )
+    return talk
+
+
 ALL_STATUSES = [
     "waiting_for_files",
     "detecting",
@@ -267,15 +337,13 @@ ALLOWED_MEDIA_CATEGORIES = frozenset(
 
 @router.get("/media/{talk_id}/{filename}")
 def get_talk_media_default(
+    request: Request,
     talk_id: int,
     filename: str,
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
-    client: Annotated[models.Client, Depends(get_ui_client)],
 ):
-    talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
-        raise HTTPException(status_code=404, detail="Media not found")
+    _authorize_studio_talk(talk_id, request, db, not_found_detail="Media not found")
 
     safe_filename = Path(filename).name
     candidate_keys = [
@@ -299,20 +367,18 @@ def get_talk_media_default(
 
 @router.get("/media/{talk_id}/{category}/{filename}")
 def get_talk_media_categorized(
+    request: Request,
     talk_id: int,
     category: str,
     filename: str,
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
-    client: Annotated[models.Client, Depends(get_ui_client)],
 ):
     safe_category = Path(category).name
     if safe_category not in ALLOWED_MEDIA_CATEGORIES:
         raise HTTPException(status_code=404, detail="Media not found")
 
-    talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
-        raise HTTPException(status_code=404, detail="Media not found")
+    _authorize_studio_talk(talk_id, request, db, not_found_detail="Media not found")
 
     safe_filename = Path(filename).name
     key = f"{talk_id}/{safe_category}/{safe_filename}"
@@ -332,11 +398,10 @@ def studio(
     talk_id: int,
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
-    client: Annotated[models.Client, Depends(get_ui_client)],
 ):
-    talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
-        raise HTTPException(status_code=404, detail="Talk not found")
+    talk = _authorize_studio_talk(
+        talk_id, request, db, not_found_detail="Talk not found"
+    )
 
     jobs = (
         db.query(models.Job)
@@ -567,7 +632,12 @@ def delete_studio_event(
             detail="Operation requires minimum role 'organizer'",
         )
 
-    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    event = (
+        db.query(models.Event)
+        .filter(models.Event.id == event_id)
+        .with_for_update()
+        .first()
+    )
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"

--- a/app/routes/studio.py
+++ b/app/routes/studio.py
@@ -578,11 +578,19 @@ def delete_studio_event(
             detail="User is not authorized to delete this event",
         )
 
+    failed_talk_ids = []
     for talk in event.talks:
         try:
             storage.delete(str(talk.id))
         except Exception as exc:  # noqa: BLE001
             logger.debug("Failed deleting storage for talk %s: %s", talk.id, exc)
+            failed_talk_ids.append(talk.id)
+
+    if failed_talk_ids:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed deleting storage for talks: {failed_talk_ids}",
+        )
 
     db.delete(event)
     db.commit()

--- a/app/routes/studio.py
+++ b/app/routes/studio.py
@@ -1,21 +1,26 @@
+import logging
 from pathlib import Path
 from typing import Annotated
 
 from fastapi import (
     APIRouter,
     Depends,
+    Form,
     HTTPException,
     Request,
     status,
 )
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session, selectinload
 
 from app import models
 from app.auth import hash_api_key
 from app.db import get_db
+from app.routes.auth import _get_authenticated_user_from_cookie
 from app.storage import StorageBackend, get_storage_backend
 from app.ui.templating import templates
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/studio", tags=["studio"])
 
@@ -144,14 +149,53 @@ def dashboard(
     status_filter: str | None = None,
     q: str | None = None,
 ):
-    query = db.query(models.Talk).options(selectinload(models.Talk.jobs))
-    if client is not None:
-        query = query.filter(models.Talk.event_id.in_(client.event_ids))
-    if event_id is not None:
-        if client is not None and event_id not in client.event_ids:
-            query = query.filter(models.Talk.id == -1)
+    user = _get_authenticated_user_from_cookie(request, db)
+    if user:
+        if user.role == "admin":
+            user_events = db.query(models.Event).order_by(models.Event.name.asc()).all()
         else:
+            user_events = (
+                db.query(models.Event)
+                .filter(models.Event.created_by_user_id == user.id)
+                .order_by(models.Event.name.asc())
+                .all()
+            )
+    elif client is not None:
+        user_events = (
+            db.query(models.Event)
+            .filter(models.Event.id.in_(client.event_ids))
+            .order_by(models.Event.name.asc())
+            .all()
+        )
+    else:
+        user_events = []
+
+    query = db.query(models.Talk).options(selectinload(models.Talk.jobs))
+    if user:
+        if user.role == "organizer":
+            org_event_ids = [e.id for e in user_events]
+            query = query.filter(models.Talk.event_id.in_(org_event_ids))
+            if event_id is not None:
+                if event_id not in org_event_ids:
+                    query = query.filter(models.Talk.id == -1)
+                else:
+                    query = query.filter(models.Talk.event_id == event_id)
+        elif user.role == "admin":
+            if event_id is not None:
+                query = query.filter(models.Talk.event_id == event_id)
+        else:
+            query = query.filter(models.Talk.id == -1)
+    elif client is not None:
+        query = query.filter(models.Talk.event_id.in_(client.event_ids))
+        if event_id is not None:
+            if event_id not in client.event_ids:
+                query = query.filter(models.Talk.id == -1)
+            else:
+                query = query.filter(models.Talk.event_id == event_id)
+    else:
+        if event_id is not None:
             query = query.filter(models.Talk.event_id == event_id)
+
     if status_filter:
         query = query.filter(models.Talk.status == status_filter)
 
@@ -160,7 +204,19 @@ def dashboard(
         q_lower = q.lower()
         talks = [t for t in talks if q_lower in t.title.lower()]
 
-    if client is not None:
+    if user:
+        if user.role == "organizer":
+            org_event_ids = [e.id for e in user_events]
+            all_talks = (
+                db.query(models.Talk)
+                .filter(models.Talk.event_id.in_(org_event_ids))
+                .all()
+            )
+        elif user.role == "admin":
+            all_talks = db.query(models.Talk).all()
+        else:
+            all_talks = []
+    elif client is not None:
         all_talks = (
             db.query(models.Talk)
             .filter(models.Talk.event_id.in_(client.event_ids))
@@ -197,6 +253,7 @@ def dashboard(
             "q": q or "",
             "status_filter": status_filter or "",
             "event_id": event_id,
+            "user_events": user_events,
         },
         headers={"Cache-Control": "no-store"},
     )
@@ -349,3 +406,184 @@ def studio(
         },
         headers={"Cache-Control": "no-store"},
     )
+
+
+@router.get("/events", response_class=HTMLResponse)
+def list_studio_events(
+    request: Request,
+    db: Annotated[Session, Depends(get_db)],
+):
+    user = _get_authenticated_user_from_cookie(request, db)
+    if not user:
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+
+    if user.role not in ("organizer", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation requires minimum role 'organizer'",
+        )
+
+    if user.role == "admin":
+        events = (
+            db.query(models.Event)
+            .options(selectinload(models.Event.created_by_user))
+            .order_by(models.Event.id.asc())
+            .all()
+        )
+    else:
+        events = (
+            db.query(models.Event)
+            .options(selectinload(models.Event.created_by_user))
+            .filter(models.Event.created_by_user_id == user.id)
+            .order_by(models.Event.id.asc())
+            .all()
+        )
+
+    return templates.TemplateResponse(
+        request,
+        "events.html.jinja",
+        {
+            "events": events,
+            "error": None,
+        },
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.post("/events", response_class=HTMLResponse)
+def create_studio_event(
+    request: Request,
+    db: Annotated[Session, Depends(get_db)],
+    name: Annotated[str, Form()] = "",
+):
+    user = _get_authenticated_user_from_cookie(request, db)
+    if not user:
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+
+    if user.role not in ("organizer", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation requires minimum role 'organizer'",
+        )
+
+    clean_name = name.strip()
+    if not clean_name:
+        if user.role == "admin":
+            events = (
+                db.query(models.Event)
+                .options(selectinload(models.Event.created_by_user))
+                .order_by(models.Event.id.asc())
+                .all()
+            )
+        else:
+            events = (
+                db.query(models.Event)
+                .options(selectinload(models.Event.created_by_user))
+                .filter(models.Event.created_by_user_id == user.id)
+                .order_by(models.Event.id.asc())
+                .all()
+            )
+        return templates.TemplateResponse(
+            request,
+            "events.html.jinja",
+            {
+                "events": events,
+                "error": "Event name is required.",
+            },
+            status_code=status.HTTP_400_BAD_REQUEST,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    event = models.Event(
+        name=clean_name,
+        created_by_user_id=user.id,
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+
+    return RedirectResponse(
+        url=f"/studio?event_id={event.id}",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@router.post("/events/{event_id}/edit", response_class=HTMLResponse)
+def edit_studio_event(
+    request: Request,
+    event_id: int,
+    db: Annotated[Session, Depends(get_db)],
+    name: Annotated[str, Form()] = "",
+):
+    user = _get_authenticated_user_from_cookie(request, db)
+    if not user:
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+
+    if user.role not in ("organizer", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation requires minimum role 'organizer'",
+        )
+
+    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
+
+    if user.role != "admin" and event.created_by_user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not authorized to edit this event",
+        )
+
+    clean_name = name.strip()
+    if not clean_name:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Event name cannot be empty",
+        )
+
+    event.name = clean_name
+    db.commit()
+    return RedirectResponse(url="/studio/events", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/events/{event_id}/delete", response_class=HTMLResponse)
+def delete_studio_event(
+    request: Request,
+    event_id: int,
+    db: Annotated[Session, Depends(get_db)],
+    storage: Annotated[StorageBackend, Depends(get_storage_backend)],
+):
+    user = _get_authenticated_user_from_cookie(request, db)
+    if not user:
+        return RedirectResponse(url="/login", status_code=status.HTTP_302_FOUND)
+
+    if user.role not in ("organizer", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operation requires minimum role 'organizer'",
+        )
+
+    event = db.query(models.Event).filter(models.Event.id == event_id).first()
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
+
+    if user.role != "admin" and event.created_by_user_id != user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not authorized to delete this event",
+        )
+
+    for talk in event.talks:
+        try:
+            storage.delete(str(talk.id))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed deleting storage for talk %s: %s", talk.id, exc)
+
+    db.delete(event)
+    db.commit()
+    return RedirectResponse(url="/studio/events", status_code=status.HTTP_303_SEE_OTHER)

--- a/app/routes/talks.py
+++ b/app/routes/talks.py
@@ -19,7 +19,6 @@ from fastapi import (
     status,
 )
 from rq.command import send_stop_job_command
-from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -1148,21 +1147,10 @@ async def import_schedule(
             event = existing_event
         else:
             created_by = user.user_id if not user.is_machine else None
-            event = models.Event(
-                id=target_event_id, name=event_name, created_by_user_id=created_by
-            )
+            event = models.Event(name=event_name, created_by_user_id=created_by)
             db.add(event)
             db.flush()
             is_new_event = True
-            try:
-                with db.begin_nested():
-                    db.execute(
-                        text(
-                            "SELECT setval(pg_get_serial_sequence('events', 'id'), (SELECT MAX(id) FROM events))"
-                        )
-                    )
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("Failed coordinating event sequence: %s", exc)
 
     if not event:
         # Check if caller already has an event with matching name

--- a/app/routes/talks.py
+++ b/app/routes/talks.py
@@ -24,7 +24,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app import models, schemas
-from app.auth import get_client, verify_event_access
+from app.auth import (
+    CurrentUser,
+    check_event_access,
+    get_current_user,
+    require_role,
+)
 from app.config import settings
 from app.db import get_db
 from app.ingest import (
@@ -49,7 +54,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/talks",
     tags=["talks"],
-    dependencies=[Depends(get_client)],
 )
 
 
@@ -57,7 +61,7 @@ router = APIRouter(
 def create_or_update_talk(
     payload: schemas.TalkCreate,
     response: Response,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
 ):
     """
@@ -65,7 +69,7 @@ def create_or_update_talk(
     Idempotent on the natural key (event_id, title, start).
     Returns 201 Created on insert, 200 OK on update (preserving existing talk status).
     """
-    verify_event_access(payload.event_id, client)
+    check_event_access(payload.event_id, user, db)
 
     talk = (
         db.query(models.Talk)
@@ -123,7 +127,7 @@ def create_or_update_talk(
 @router.get("/{talk_id}", response_model=schemas.TalkWithJobsRead)
 def get_talk(
     talk_id: int,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -132,10 +136,11 @@ def get_talk(
     Returns 404 if the talk does not exist or is not authorized under caller's event_ids.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     candidate_keys = [
         f"{talk.id}/preview/{name}.mp4" for name in settings.preview_presets
@@ -153,15 +158,16 @@ def get_talk(
 @router.get("/{talk_id}/jobs", response_model=schemas.TalkJobsResponse)
 def get_talk_jobs(
     talk_id: int,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ):
     """Returns the current talk status along with recent jobs and active progress."""
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
     jobs = (
         db.query(models.Job)
         .filter(models.Job.talk_id == talk_id)
@@ -185,7 +191,7 @@ def get_talk_jobs(
 def ingest_recording(
     talk_id: int,
     payload: schemas.RecordingIngestRequest,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -197,10 +203,11 @@ def ingest_recording(
     Returns 507 if storage space is insufficient.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status != "waiting_for_files":
         raise HTTPException(
@@ -248,7 +255,7 @@ def ingest_recording(
 )
 def approve_talk(
     talk_id: int,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
     payload: schemas.ApproveRequest | None = None,
@@ -261,10 +268,11 @@ def approve_talk(
     Returns 409 if talk status is not 'pending_approval'.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status != "pending_approval":
         raise HTTPException(
@@ -310,7 +318,7 @@ RAW_PREVIEW_ALLOWED_STATES = frozenset(
 )
 def raw_preview(
     talk_id: int,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -321,10 +329,11 @@ def raw_preview(
     Returns 404 if talk not found or no raw file exists.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status not in RAW_PREVIEW_ALLOWED_STATES:
         raise HTTPException(
@@ -349,7 +358,7 @@ def raw_preview(
 def submit_cut_bounds(
     talk_id: int,
     payload: schemas.CutBoundsRequest,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -360,10 +369,11 @@ def submit_cut_bounds(
     Returns 409 if not in pending_bounds. Returns 422 if bounds are invalid.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status != "pending_bounds":
         raise HTTPException(
@@ -423,7 +433,7 @@ def submit_cut_bounds(
 def configure_assembly(
     talk_id: int,
     payload: schemas.IntroOutroRequest,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -443,10 +453,11 @@ def configure_assembly(
         .with_for_update()
         .first()
     )
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status != "pending_intro_outro":
         raise HTTPException(
@@ -609,7 +620,7 @@ def _cancel_talk_jobs(talk_id: int, storage: StorageBackend | None = None) -> No
 )
 def abort_talk(
     talk_id: int,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -619,10 +630,11 @@ def abort_talk(
     Returns 404 if talk is not found or not authorized for caller's events.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     _cancel_talk_jobs(talk.id, storage)
 
@@ -651,7 +663,7 @@ def abort_talk(
 def update_talk(
     talk_id: int,
     payload: schemas.TalkUpdate,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
 ):
     """
@@ -659,10 +671,11 @@ def update_talk(
     Returns 404 if talk is not found or not in caller's event_ids.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if payload.title is not None:
         title = payload.title.strip()
@@ -703,7 +716,7 @@ def update_talk(
 @router.delete("/{talk_id}", status_code=status.HTTP_200_OK)
 def delete_talk(
     talk_id: int,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -712,10 +725,11 @@ def delete_talk(
     Returns 404 if talk is not found or not in caller's event_ids.
     """
     talk = db.query(models.Talk).filter(models.Talk.id == talk_id).first()
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     _cancel_talk_jobs(talk_id, storage)
     db.query(models.Review).filter(models.Review.talk_id == talk_id).delete()
@@ -729,7 +743,7 @@ def delete_talk(
 @router.post("/bulk-delete", response_model=schemas.BulkDeleteResponse)
 def bulk_delete_talks(
     payload: schemas.BulkDeleteRequest,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -740,14 +754,34 @@ def bulk_delete_talks(
     if not payload.talk_ids:
         return {"status": "ok", "deleted_count": 0}
 
-    valid_talks = (
-        db.query(models.Talk)
-        .filter(
-            models.Talk.id.in_(payload.talk_ids),
-            models.Talk.event_id.in_(client.event_ids),
+    if user.is_machine:
+        valid_talks = (
+            db.query(models.Talk)
+            .filter(
+                models.Talk.id.in_(payload.talk_ids),
+                models.Talk.event_id.in_(user.event_ids),
+            )
+            .all()
         )
-        .all()
-    )
+    elif user.role == "admin":
+        valid_talks = (
+            db.query(models.Talk).filter(models.Talk.id.in_(payload.talk_ids)).all()
+        )
+    else:
+        org_event_ids = [
+            e.id
+            for e in db.query(models.Event.id)
+            .filter(models.Event.created_by_user_id == user.user_id)
+            .all()
+        ]
+        valid_talks = (
+            db.query(models.Talk)
+            .filter(
+                models.Talk.id.in_(payload.talk_ids),
+                models.Talk.event_id.in_(org_event_ids),
+            )
+            .all()
+        )
 
     deleted_count = 0
     for talk in valid_talks:
@@ -769,7 +803,7 @@ def bulk_delete_talks(
 async def upload_recording(
     talk_id: int,
     file: Annotated[UploadFile, File()],
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     storage: Annotated[StorageBackend, Depends(get_storage_backend)],
 ):
@@ -783,10 +817,11 @@ async def upload_recording(
         .with_for_update()
         .first()
     )
-    if not talk or talk.event_id not in client.event_ids:
+    if not talk or (user.is_machine and talk.event_id not in user.event_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Talk not found"
         )
+    check_event_access(talk.event_id, user, db)
 
     if talk.status != "waiting_for_files":
         raise HTTPException(
@@ -889,7 +924,7 @@ MAX_SCHEDULE_IMPORT_SIZE = 10 * 1024 * 1024  # 10MB
 @router.post("/schedule/import", response_model=schemas.ScheduleImportResponse)
 async def import_schedule(
     request: Request,
-    client: Annotated[models.Client, Depends(get_client)],
+    user: Annotated[CurrentUser, Depends(require_role("organizer"))],
     db: Annotated[Session, Depends(get_db)],
     file: Annotated[UploadFile | None, File()] = None,
 ):
@@ -1088,13 +1123,19 @@ async def import_schedule(
 
     target_event_id = None
     if isinstance(data, dict) and data.get("event_id"):
-        target_event_id = data.get("event_id")
+        try:
+            target_event_id = int(data.get("event_id"))
+        except ValueError, TypeError:
+            pass
     elif (
         talks_to_create
         and isinstance(talks_to_create[0], dict)
         and talks_to_create[0].get("event_id")
     ):
-        target_event_id = talks_to_create[0].get("event_id")
+        try:
+            target_event_id = int(talks_to_create[0].get("event_id"))
+        except ValueError, TypeError:
+            pass
 
     event = None
     is_new_event = False
@@ -1103,10 +1144,13 @@ async def import_schedule(
             db.query(models.Event).filter(models.Event.id == target_event_id).first()
         )
         if existing_event:
-            verify_event_access(target_event_id, client)
+            check_event_access(target_event_id, user, db)
             event = existing_event
         else:
-            event = models.Event(id=target_event_id, name=event_name)
+            created_by = user.user_id if not user.is_machine else None
+            event = models.Event(
+                id=target_event_id, name=event_name, created_by_user_id=created_by
+            )
             db.add(event)
             db.flush()
             is_new_event = True
@@ -1122,24 +1166,50 @@ async def import_schedule(
 
     if not event:
         # Check if caller already has an event with matching name
-        event = (
-            db.query(models.Event)
-            .filter(
-                models.Event.name == event_name,
-                models.Event.id.in_(client.event_ids),
+        if user.is_machine:
+            event = (
+                db.query(models.Event)
+                .filter(
+                    models.Event.name == event_name,
+                    models.Event.id.in_(user.event_ids),
+                )
+                .first()
             )
-            .first()
-        )
+        elif user.role == "admin":
+            event = (
+                db.query(models.Event).filter(models.Event.name == event_name).first()
+            )
+        else:
+            event = (
+                db.query(models.Event)
+                .filter(
+                    models.Event.name == event_name,
+                    models.Event.created_by_user_id == user.user_id,
+                )
+                .first()
+            )
 
     if not event:
-        event = models.Event(name=event_name)
+        created_by = user.user_id if not user.is_machine else None
+        event = models.Event(name=event_name, created_by_user_id=created_by)
         db.add(event)
         db.flush()
         is_new_event = True
 
-    # Ensure client has access to this newly created event
-    if is_new_event and event.id not in client.event_ids:
-        client.event_ids = list(set(client.event_ids + [event.id]))
+    # Ensure machine client has access to this newly created event
+    if is_new_event and user.is_machine:
+        if event.id not in user.event_ids:
+            user.event_ids.append(event.id)
+        if user.client_id:
+            client_record = (
+                db.query(models.Client)
+                .filter(models.Client.id == user.client_id)
+                .first()
+            )
+            if client_record and event.id not in (client_record.event_ids or []):
+                client_record.event_ids = list(
+                    set((client_record.event_ids or []) + [event.id])
+                )
 
     created_count = 0
     for v_talk in validated_talks:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -31,8 +31,21 @@ class EventCreate(EventBase):
     pass
 
 
+class EventUpdate(BaseModel):
+    name: str | None = None
+    retention_overrides: dict[str, Any] | None = None
+
+    @field_validator("retention_overrides")
+    @classmethod
+    def _validate_retention_overrides(
+        cls, v: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        return validate_retention_overrides(v)
+
+
 class EventRead(EventBase):
     id: int
+    created_by_user_id: int | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -171,6 +184,7 @@ class ReviewRead(ReviewBase):
     id: int
     talk_id: int
     created_at: datetime
+    user_id: int | None = None
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/app/ui/static/css/events.css
+++ b/app/ui/static/css/events.css
@@ -1,0 +1,161 @@
+/* ── Events Page Styles (events.html) ─────────────────────────── */
+
+.event-create-card {
+  background: var(--v-bg-surface);
+  border: 1px solid var(--v-border-subtle);
+  border-radius: var(--v-radius-lg);
+  padding: 20px 24px;
+  margin-bottom: 24px;
+}
+
+.event-create-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--v-text-primary);
+  margin-bottom: 6px;
+}
+
+.event-create-desc {
+  font-size: 0.82rem;
+  color: var(--v-text-muted);
+  margin-bottom: 16px;
+}
+
+.event-create-form {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.event-create-field {
+  flex: 1;
+  min-width: 260px;
+}
+
+.event-create-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--v-text-secondary);
+  margin-bottom: 6px;
+}
+
+.table-count-spaced {
+  margin-left: 8px;
+}
+
+.col-id {
+  width: 80px;
+  padding-left: 18px;
+}
+
+.col-actions-right {
+  text-align: right;
+  padding-right: 18px;
+}
+
+.row-actions-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.btn-danger-ghost {
+  color: #ef4444;
+}
+
+.btn-danger-ghost:hover {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.event-title-link {
+  color: var(--v-text-primary);
+  text-decoration: none;
+}
+
+.event-title-link:hover {
+  color: var(--v-primary);
+  text-decoration: underline;
+}
+
+.text-muted {
+  color: var(--v-text-muted);
+}
+
+.events-empty-state {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--v-text-muted);
+}
+
+.events-empty-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--v-text-primary);
+  margin-bottom: 6px;
+}
+
+.events-empty-desc {
+  font-size: 0.82rem;
+}
+
+/* ── Edit Modal ───────────────────────────────────────────────── */
+.events-modal-backdrop {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 100;
+  align-items: center;
+  justify-content: center;
+}
+
+.events-modal-backdrop.active {
+  display: flex;
+}
+
+.events-modal-card {
+  background: var(--v-bg-surface);
+  border: 1px solid var(--v-border-subtle);
+  border-radius: var(--v-radius-lg);
+  width: 90%;
+  max-width: 440px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.events-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.events-modal-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--v-text-primary);
+  margin: 0;
+}
+
+.events-modal-field {
+  margin-bottom: 16px;
+}
+
+.events-modal-desc {
+  font-size: 0.85rem;
+  color: var(--v-text-secondary);
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+
+.events-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/app/ui/static/js/dashboard.js
+++ b/app/ui/static/js/dashboard.js
@@ -81,9 +81,13 @@ function renderActiveJobCell(cell, statusText, pct, remainingStr) {
 
 async function pollTalk(talkId) {
   try {
+    const isSessionLoggedIn = Boolean(
+      document.querySelector('.user-email') ||
+      document.getElementById('logout-btn')
+    );
     const key = (window.getApiKey && window.getApiKey()) || '';
-    if (!key) return;
-    const headers = { 'X-API-Key': key };
+    if (!key && !isSessionLoggedIn) return;
+    const headers = key ? { 'X-API-Key': key } : {};
     const cell = document.querySelector(`.status-cell[data-talk-id="${talkId}"]`);
     const row  = document.querySelector(`tr[data-talk-id="${talkId}"]`);
     if (!cell) return;
@@ -91,7 +95,7 @@ async function pollTalk(talkId) {
     let talkStatus = row ? row.dataset.status : '';
     let jobs = [];
 
-    const r = await (window.authFetch || fetch)(`/studio/talks/${talkId}/jobs`, { headers, _isPolling: true });
+    const r = await (window.authFetch || fetch)(`/talks/${talkId}/jobs`, { headers, _isPolling: true });
     if (!r.ok) return;
     const data = await r.json();
     talkStatus = data.status || talkStatus;

--- a/app/ui/static/js/dashboard.js
+++ b/app/ui/static/js/dashboard.js
@@ -293,7 +293,11 @@ window.submitScheduleImport = async function() {
 
     const data = await res.json();
     alert(`Successfully imported ${data.imported_count} session(s) into "${data.event_name}"!`);
-    location.reload();
+    if (data && data.event_id) {
+      window.location.href = `/studio?event_id=${data.event_id}`;
+    } else {
+      location.reload();
+    }
   } catch (err) {
     alert(`Import failed: ${err.message}`);
   } finally {
@@ -302,15 +306,30 @@ window.submitScheduleImport = async function() {
 };
 
 window.submitQuickTalk = async function() {
-  const eventName = (document.getElementById('quick-event-name') || {}).value || 'General Conference';
-  const title = (document.getElementById('quick-talk-title') || {}).value || '';
+  const eventElem = document.getElementById('quick-event-name');
+  let eventName = 'General Conference';
+  let eventId = null;
+  if (eventElem) {
+    eventName = eventElem.value || 'General Conference';
+    if (eventElem.tagName === 'SELECT') {
+      const opt = eventElem.options[eventElem.selectedIndex];
+      if (opt && opt.dataset && opt.dataset.eventId) {
+        eventId = parseInt(opt.dataset.eventId, 10);
+      }
+    }
+  }
+  const titleInput = document.getElementById('quick-talk-title');
+  const title = (titleInput ? titleInput.value : '').trim();
   const room = (document.getElementById('quick-talk-room') || {}).value || 'Auditorium A';
   const startVal = (document.getElementById('quick-talk-start') || {}).value || '';
   const endVal = (document.getElementById('quick-talk-end') || {}).value || '';
   const btn = document.getElementById('btn-submit-quick-talk');
   const orig = btn ? btn.innerHTML : '';
 
-  if (!title.trim()) {
+  if (!title) {
+    if (titleInput) {
+      titleInput.focus();
+    }
     alert('Please enter a talk title.');
     return;
   }
@@ -329,6 +348,10 @@ window.submitQuickTalk = async function() {
       room,
     };
 
+    if (eventId) {
+      payload.event_id = eventId;
+    }
+
     if (startVal) {
       payload.start = new Date(startVal).toISOString();
     }
@@ -339,15 +362,30 @@ window.submitQuickTalk = async function() {
     const res = await (window.authFetch || fetch)('/talks/schedule/import', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
       body: JSON.stringify(payload),
     });
 
     if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      throw new Error(err.detail || `Server returned ${res.status}`);
+      const errData = await res.json().catch(() => ({}));
+      let msg = errData.detail || `Server returned ${res.status}`;
+      if (Array.isArray(msg)) {
+        msg = msg.map((e) => (e && e.msg ? e.msg : JSON.stringify(e))).join(', ');
+      } else if (typeof msg === 'object' && msg !== null) {
+        msg = JSON.stringify(msg);
+      }
+      throw new Error(msg);
     }
 
-    location.reload();
+    const data = await res.json().catch(() => ({}));
+    const targetEventId = (data && data.event_id) ? data.event_id : eventId;
+    const targetUrl = targetEventId ? `/studio?event_id=${targetEventId}` : '/studio';
+
+    if (window.location.pathname + window.location.search === targetUrl) {
+      window.location.reload();
+    } else {
+      window.location.href = targetUrl;
+    }
   } catch (err) {
     alert(`Failed to create talk: ${err.message}`);
     if (btn) { btn.disabled = false; btn.innerHTML = orig; }
@@ -488,6 +526,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const btnSubmitQuickTalk = document.getElementById('btn-submit-quick-talk');
   if (btnSubmitQuickTalk) btnSubmitQuickTalk.addEventListener('click', window.submitQuickTalk);
+
+  ['quick-talk-title', 'quick-talk-room'].forEach((id) => {
+    const input = document.getElementById(id);
+    if (input) {
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          window.submitQuickTalk();
+        }
+      });
+    }
+  });
 
   const selectAll = document.getElementById('select-all-talks');
   if (selectAll) selectAll.addEventListener('change', () => window.toggleSelectAllTalks(selectAll));

--- a/app/ui/static/js/events.js
+++ b/app/ui/static/js/events.js
@@ -1,0 +1,67 @@
+// ── Events Management (events.html) ────────────────────────────
+
+document.addEventListener('DOMContentLoaded', () => {
+  const editModal = document.getElementById('modal-edit-event');
+  const editForm = document.getElementById('edit-event-form');
+  const editInput = document.getElementById('edit-event-name');
+
+  const deleteModal = document.getElementById('modal-delete-event');
+  const deleteForm = document.getElementById('delete-event-form');
+  const deleteNameDisplay = document.getElementById('delete-event-name-display');
+
+  // Open edit modal
+  document.querySelectorAll('.btn-edit-event').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-event-id');
+      const name = btn.getAttribute('data-event-name');
+      if (editForm && editInput) {
+        editForm.action = `/studio/events/${id}/edit`;
+        editInput.value = name || '';
+      }
+      if (editModal) {
+        editModal.classList.add('active');
+        if (editInput) editInput.focus();
+      }
+    });
+  });
+
+  // Close edit modal
+  document.querySelectorAll('.btn-close-edit-modal').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (editModal) editModal.classList.remove('active');
+    });
+  });
+
+  // Open delete modal
+  document.querySelectorAll('.btn-delete-event').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-event-id');
+      const name = btn.getAttribute('data-event-name') || 'this event';
+      if (deleteForm && deleteNameDisplay) {
+        deleteForm.action = `/studio/events/${id}/delete`;
+        deleteNameDisplay.textContent = `"${name}"`;
+      }
+      if (deleteModal) {
+        deleteModal.classList.add('active');
+      }
+    });
+  });
+
+  // Close delete modal
+  document.querySelectorAll('.btn-close-delete-modal').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (deleteModal) deleteModal.classList.remove('active');
+    });
+  });
+
+  // Close modals when clicking backdrop
+  [editModal, deleteModal].forEach(modal => {
+    if (modal) {
+      modal.addEventListener('click', (e) => {
+        if (e.target === modal) {
+          modal.classList.remove('active');
+        }
+      });
+    }
+  });
+});

--- a/app/ui/static/js/theme.js
+++ b/app/ui/static/js/theme.js
@@ -85,13 +85,20 @@ window.setUserRole = function (role) {
 
 window.authFetch = function (url, options = {}) {
   options.headers = options.headers || {};
-  const key = window.getApiKey();
-  if (key) {
-    if (options.headers instanceof Headers) {
-      options.headers.set('X-API-Key', key);
-    } else {
-      options.headers['X-API-Key'] = key;
+  const isSessionLoggedIn = Boolean(
+    document.querySelector('.user-email') ||
+    document.getElementById('logout-btn')
+  );
+  if (!isSessionLoggedIn) {
+    const key = window.getApiKey();
+    if (key) {
+      if (options.headers instanceof Headers) {
+        options.headers.set('X-API-Key', key);
+      } else {
+        options.headers['X-API-Key'] = key;
+      }
     }
   }
+  options.credentials = options.credentials || 'same-origin';
   return fetch(url, options);
 };

--- a/app/ui/templates/base.html.jinja
+++ b/app/ui/templates/base.html.jinja
@@ -27,6 +27,17 @@
 
     <nav class="sidebar-nav">
       <span class="nav-label">Workspace</span>
+      {% if user and user.role in ['organizer', 'admin'] %}
+      <a href="/studio/events" class="nav-item {% if '/events' in request.url.path %}active{% endif %}" id="nav-events-link">
+        <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+          <line x1="16" y1="2" x2="16" y2="6"/>
+          <line x1="8" y1="2" x2="8" y2="6"/>
+          <line x1="3" y1="10" x2="21" y2="10"/>
+        </svg>
+        Events
+      </a>
+      {% endif %}
       <a href="/studio" class="nav-item {% if request.url.path == '/studio' and not request.query_params.get('status_filter') %}active{% endif %}">
         <svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <rect x="3" y="3" width="7" height="7"/>

--- a/app/ui/templates/dashboard.html.jinja
+++ b/app/ui/templates/dashboard.html.jinja
@@ -120,6 +120,12 @@
         <span class="table-count table-count-spaced">{{ talks | length }} result{% if talks | length != 1 %}s{% endif %}</span>
       </div>
       <div class="table-header-actions">
+        {% if user and user.role in ['organizer', 'admin'] %}
+        <a href="/studio/events" class="btn btn-ghost btn-sm" id="btn-events-link">
+          <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+          Events
+        </a>
+        {% endif %}
         <button class="btn btn-ghost btn-sm" id="btn-open-import">
           <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Import Schedule
@@ -304,12 +310,20 @@
 
     <div class="dashboard-modal-field-sm">
       <label class="dashboard-modal-label dashboard-modal-label-tight">Event Name</label>
+      {% if user_events %}
+      <select id="quick-event-name" class="input-field">
+        {% for ev in user_events %}
+          <option value="{{ ev.name }}" data-event-id="{{ ev.id }}" {% if event_id == ev.id %}selected{% endif %}>{{ ev.name }}</option>
+        {% endfor %}
+      </select>
+      {% else %}
       <input type="text" id="quick-event-name" class="input-field" value="FOSSASIA Summit 2026">
+      {% endif %}
     </div>
 
     <div class="dashboard-modal-field-sm">
       <label class="dashboard-modal-label dashboard-modal-label-tight">Talk Title</label>
-      <input type="text" id="quick-talk-title" class="input-field" placeholder="e.g. Building Open Video Systems">
+      <input type="text" id="quick-talk-title" class="input-field" placeholder="e.g. Building Open Video Systems" required>
     </div>
 
     <div class="dashboard-modal-field-sm">

--- a/app/ui/templates/events.html.jinja
+++ b/app/ui/templates/events.html.jinja
@@ -1,0 +1,158 @@
+{% extends "base.html.jinja" %}
+
+{% block title %}Events — VEditor{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="/static/css/events.css">
+{% endblock %}
+
+{% block breadcrumb %}
+  <span class="current">Events</span>
+{% endblock %}
+
+{% block content %}
+<div class="page-body">
+
+  {% if error %}
+    <div class="alert alert-danger" role="alert">
+      <span>{{ error }}</span>
+    </div>
+  {% endif %}
+
+  <!-- Event Creation Form Card -->
+  <div class="event-create-card">
+    <h2 class="event-create-title">Create Event</h2>
+    <p class="event-create-desc">Add a new event workspace to manage talks and video pipelines.</p>
+    <form method="post" action="/studio/events" class="event-create-form">
+      <div class="event-create-field">
+        <label for="event-name" class="event-create-label">Event Name</label>
+        <input
+          type="text"
+          id="event-name"
+          name="name"
+          class="input-field"
+          placeholder="e.g. FOSSASIA Summit 2026"
+          required
+        >
+      </div>
+      <button type="submit" class="btn btn-primary" id="btn-create-event">
+        Create Event
+      </button>
+    </form>
+  </div>
+
+  <!-- Events List Table -->
+  <div class="table-wrap">
+    <div class="table-header">
+      <div>
+        <span class="table-title">Events</span>
+        <span class="table-count table-count-spaced">{{ events | length }} event{% if events | length != 1 %}s{% endif %}</span>
+      </div>
+    </div>
+
+    {% if events %}
+    <table>
+      <thead>
+        <tr>
+          <th class="col-id">ID</th>
+          <th>Event Name</th>
+          <th>Created By / Owner</th>
+          <th class="col-actions-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for event in events %}
+        <tr>
+          <td class="td-mono col-id">#{{ event.id }}</td>
+          <td class="td-title">
+            <a href="/studio?event_id={{ event.id }}" class="event-title-link">
+              <strong>{{ event.name }}</strong>
+            </a>
+          </td>
+          <td>
+            {% if event.created_by_user %}
+              {{ event.created_by_user.email }}
+            {% elif event.created_by_user_id %}
+              User #{{ event.created_by_user_id }}
+            {% else %}
+              <span class="text-muted">—</span>
+            {% endif %}
+          </td>
+          <td class="col-actions-right">
+            <div class="row-actions-group">
+              <a href="/studio?event_id={{ event.id }}" class="btn btn-ghost btn-sm" title="Open Event">
+                View Talks
+              </a>
+              <button type="button" class="btn btn-ghost btn-sm btn-edit-event" data-event-id="{{ event.id }}" data-event-name="{{ event.name }}" title="Edit Event Name">
+                Edit
+              </button>
+              <button type="button" class="btn btn-ghost btn-sm btn-delete-event btn-danger-ghost" data-event-id="{{ event.id }}" data-event-name="{{ event.name }}" title="Delete Event">
+                Delete
+              </button>
+            </div>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="events-empty-state">
+      <p class="events-empty-title">No events found</p>
+      <p class="events-empty-desc">No events found. Create your first event above.</p>
+    </div>
+    {% endif %}
+  </div>
+
+</div>
+
+<!-- ── MODAL: Edit Event ─────────────────────────────────────────── -->
+<div id="modal-edit-event" class="events-modal-backdrop">
+  <div class="events-modal-card">
+    <div class="events-modal-header">
+      <h3 class="events-modal-title">Edit Event Name</h3>
+      <button type="button" class="btn btn-ghost btn-sm btn-close-edit-modal">✕</button>
+    </div>
+
+    <form id="edit-event-form" method="post" action="">
+      <div class="events-modal-field">
+        <label for="edit-event-name" class="event-create-label">Event Name</label>
+        <input type="text" id="edit-event-name" name="name" class="input-field" required>
+      </div>
+
+      <div class="events-modal-footer">
+        <button type="button" class="btn btn-ghost btn-sm btn-close-edit-modal">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-sm" id="btn-save-event">
+          Save Changes
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- ── MODAL: Delete Event ───────────────────────────────────────── -->
+<div id="modal-delete-event" class="events-modal-backdrop">
+  <div class="events-modal-card">
+    <div class="events-modal-header">
+      <h3 class="events-modal-title">Delete Event</h3>
+      <button type="button" class="btn btn-ghost btn-sm btn-close-delete-modal">✕</button>
+    </div>
+
+    <form id="delete-event-form" method="post" action="">
+      <p class="events-modal-desc">
+        Are you sure you want to delete event <strong id="delete-event-name-display"></strong> and all associated talks? This action cannot be undone.
+      </p>
+
+      <div class="events-modal-footer">
+        <button type="button" class="btn btn-ghost btn-sm btn-close-delete-modal">Cancel</button>
+        <button type="submit" class="btn btn-danger btn-sm" id="btn-confirm-delete-event">
+          Delete Event
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="/static/js/events.js"></script>
+{% endblock %}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -328,6 +328,17 @@ def test_check_event_access_machine_client_in_scope():
     assert check_event_access(event_id=5, user=client_user, db=mock_db) == event
 
 
+def test_check_event_access_machine_client_not_found():
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    client_user = CurrentUser(role="admin", source="api_key", event_ids=[4, 5, 6])
+    with pytest.raises(HTTPException) as excinfo:
+        check_event_access(event_id=5, user=client_user, db=mock_db)
+    assert excinfo.value.status_code == status.HTTP_404_NOT_FOUND
+    assert excinfo.value.detail == "Event not found"
+
+
 def test_check_event_access_machine_client_out_of_scope():
     event = Event(id=10, name="PyCon", created_by_user_id=1)
     mock_db = MagicMock()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,559 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import models, schemas
+from app.auth import CurrentUser, get_client, get_current_user
+from app.db import get_db
+from app.main import app
+from app.review_handlers import handle_approve, handle_needs_work, handle_reject
+from app.storage import get_storage_backend
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+
+    def fake_flush():
+        for call in db.add.call_args_list:
+            obj = call[0][0]
+            if getattr(obj, "id", None) is None:
+                obj.id = 1
+            if getattr(obj, "created_at", None) is None:
+                obj.created_at = datetime.now(UTC)
+
+    db.flush.side_effect = fake_flush
+
+    def fake_refresh(obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = 1
+        if getattr(obj, "created_at", None) is None:
+            obj.created_at = datetime.now(UTC)
+
+    db.refresh.side_effect = fake_refresh
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Schema Tests
+# ---------------------------------------------------------------------------
+
+
+def test_event_read_schema_includes_created_by_user_id():
+    ev = schemas.EventRead(id=1, name="Test Event", created_by_user_id=42)
+    assert ev.id == 1
+    assert ev.name == "Test Event"
+    assert ev.created_by_user_id == 42
+
+    ev_none = schemas.EventRead(id=2, name="Machine Event")
+    assert ev_none.created_by_user_id is None
+
+
+def test_review_read_schema_includes_user_id():
+    rev = schemas.ReviewRead(
+        id=1,
+        talk_id=10,
+        decision="approve",
+        created_at=datetime.now(UTC),
+        user_id=7,
+    )
+    assert rev.id == 1
+    assert rev.talk_id == 10
+    assert rev.decision == "approve"
+    assert rev.user_id == 7
+
+    rev_none = schemas.ReviewRead(
+        id=2,
+        talk_id=10,
+        decision="reject",
+        created_at=datetime.now(UTC),
+    )
+    assert rev_none.user_id is None
+
+
+# ---------------------------------------------------------------------------
+# Review Handlers Unit Tests
+# ---------------------------------------------------------------------------
+
+
+def test_review_handlers_forward_user_id(mock_db):
+    talk = models.Talk(
+        id=1,
+        event_id=1,
+        title="Test Talk",
+        start=datetime.now(UTC),
+        end=datetime.now(UTC),
+        status="preview",
+    )
+    payload = schemas.ReviewRequest(
+        decision=schemas.ReviewDecision.approve, note="LGTM"
+    )
+
+    resp = handle_approve(talk, payload, mock_db, user_id=99)
+    assert resp.talk.status == "pending_intro_outro"
+    assert mock_db.add.called
+    added_review = mock_db.add.call_args[0][0]
+    assert added_review.user_id == 99
+    assert added_review.decision == "approve"
+
+    # Needs work
+    mock_db.reset_mock()
+    talk.status = "preview"
+    payload_nw = schemas.ReviewRequest(
+        decision=schemas.ReviewDecision.needs_work, note="Fix bounds"
+    )
+    resp_nw = handle_needs_work(talk, payload_nw, mock_db, user_id=88)
+    assert resp_nw.talk.status == "pending_bounds"
+    added_review_nw = mock_db.add.call_args[0][0]
+    assert added_review_nw.user_id == 88
+
+    # Reject
+    mock_db.reset_mock()
+    talk.status = "preview"
+    payload_rej = schemas.ReviewRequest(
+        decision=schemas.ReviewDecision.reject, note="Rejected"
+    )
+    resp_rej = handle_reject(talk, payload_rej, mock_db, user_id=77)
+    assert resp_rej.talk.status == "rejected"
+    added_review_rej = mock_db.add.call_args[0][0]
+    assert added_review_rej.user_id == 77
+
+
+# ---------------------------------------------------------------------------
+# POST /events Tests
+# ---------------------------------------------------------------------------
+
+
+def test_post_events_unauthorized():
+    res = client.post("/events", json={"name": "Conf 2026"})
+    assert res.status_code == 401
+
+
+def test_post_events_forbidden_for_regular_user():
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, email="user@example.com", role="user", source="jwt"
+    )
+    res = client.post("/events", json={"name": "Conf 2026"})
+    assert res.status_code == 403
+    assert "Operation requires minimum role 'organizer'" in res.json()["detail"]
+
+
+def test_post_events_success_organizer(mock_db):
+    def fake_refresh(obj):
+        obj.id = 100
+
+    mock_db.refresh.side_effect = fake_refresh
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, email="organizer@example.com", role="organizer", source="jwt"
+    )
+
+    res = client.post("/events", json={"name": "PyCon 2026"})
+    assert res.status_code == 201
+    data = res.json()
+    assert data["id"] == 100
+    assert data["name"] == "PyCon 2026"
+    assert data["created_by_user_id"] == 5
+
+    assert mock_db.add.called
+    created_event = mock_db.add.call_args[0][0]
+    assert created_event.created_by_user_id == 5
+    assert created_event.name == "PyCon 2026"
+
+
+def test_post_events_machine_client_sets_created_by_none(mock_db):
+    def fake_refresh(obj):
+        obj.id = 101
+
+    mock_db.refresh.side_effect = fake_refresh
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=None, role="admin", source="api_key", event_ids=[1, 2]
+    )
+
+    res = client.post("/events", json={"name": "Machine Event"})
+    assert res.status_code == 201
+    created_event = mock_db.add.call_args[0][0]
+    assert created_event.created_by_user_id is None
+
+
+# ---------------------------------------------------------------------------
+# GET /events Tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_events_unauthorized():
+    res = client.get("/events")
+    assert res.status_code == 401
+
+
+def test_get_events_forbidden_for_user():
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, email="user@example.com", role="user", source="jwt"
+    )
+    res = client.get("/events")
+    assert res.status_code == 403
+
+
+def test_get_events_admin_returns_all(mock_db):
+    ev1 = models.Event(id=1, name="Event 1", created_by_user_id=1)
+    ev2 = models.Event(id=2, name="Event 2", created_by_user_id=2)
+    mock_db.query.return_value.all.return_value = [ev1, ev2]
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=99, email="admin@example.com", role="admin", source="jwt"
+    )
+
+    res = client.get("/events")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 2
+    assert data[0]["id"] == 1
+    assert data[1]["id"] == 2
+
+
+def test_get_events_organizer_filters_by_user_id(mock_db):
+    ev1 = models.Event(id=1, name="Event 1", created_by_user_id=5)
+    mock_db.query.return_value.filter.return_value.all.return_value = [ev1]
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, email="org@example.com", role="organizer", source="jwt"
+    )
+
+    res = client.get("/events")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["id"] == 1
+    assert mock_db.query.return_value.filter.called
+
+
+# ---------------------------------------------------------------------------
+# POST /talks/{id}/review with user recording
+# ---------------------------------------------------------------------------
+
+
+def test_review_records_human_user_id(mock_db):
+    mock_storage = MagicMock()
+    talk = models.Talk(
+        id=5,
+        event_id=1,
+        title="Keynote",
+        start=datetime.now(UTC),
+        end=datetime.now(UTC),
+        status="preview",
+    )
+    mock_db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = talk
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_storage_backend] = lambda: mock_storage
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=42, email="reviewer@example.com", role="user", source="jwt"
+    )
+
+    res = client.post("/talks/5/review", json={"decision": "approve", "note": "Great!"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["review"]["user_id"] == 42
+
+
+def test_review_records_none_for_machine_client(mock_db):
+    mock_storage = MagicMock()
+    talk = models.Talk(
+        id=5,
+        event_id=1,
+        title="Keynote",
+        start=datetime.now(UTC),
+        end=datetime.now(UTC),
+        status="preview",
+    )
+    mock_db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = talk
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_storage_backend] = lambda: mock_storage
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=None, role="admin", source="api_key", event_ids=[1]
+    )
+
+    res = client.post("/talks/5/review", json={"decision": "approve"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["review"]["user_id"] is None
+
+
+def test_review_machine_client_forbidden_event(mock_db):
+    talk = models.Talk(
+        id=5,
+        event_id=2,  # Machine only has access to event 1
+        title="Keynote",
+        start=datetime.now(UTC),
+        end=datetime.now(UTC),
+        status="preview",
+    )
+    mock_db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = talk
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=None, role="admin", source="api_key", event_ids=[1]
+    )
+
+    res = client.post("/talks/5/review", json={"decision": "approve"})
+    assert res.status_code == 403
+    assert res.json()["detail"] == "Client is not authorized to access this event"
+
+
+# ---------------------------------------------------------------------------
+# get_client override compatibility in get_current_user
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_get_client_override_in_get_current_user(mock_db):
+    mock_client = models.Client(id=1, event_ids=[10, 20])
+    app.dependency_overrides[get_client] = lambda: mock_client
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    talk = models.Talk(
+        id=1,
+        event_id=10,
+        title="Legacy Test",
+        start=datetime.now(UTC),
+        end=datetime.now(UTC),
+        status="preview",
+    )
+    mock_db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = talk
+
+    res = client.post("/talks/1/review", json={"decision": "approve"})
+    assert res.status_code == 200
+    assert res.json()["review"]["user_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Write Endpoints Gating Tests (POST /talks, /recordings, /approve)
+# ---------------------------------------------------------------------------
+
+
+def test_post_talks_forbidden_for_user_role():
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, role="user", source="jwt"
+    )
+    res = client.post(
+        "/talks",
+        json={
+            "event_id": 1,
+            "title": "Unauthorized Talk",
+            "room": "Hall A",
+            "start": datetime.now(UTC).isoformat(),
+            "end": datetime.now(UTC).isoformat(),
+        },
+    )
+    assert res.status_code == 403
+    assert "Operation requires minimum role 'organizer'" in res.json()["detail"]
+
+
+def test_post_talks_forbidden_for_non_owning_organizer(mock_db):
+    event = models.Event(id=1, name="Other Event", created_by_user_id=99)
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.post(
+        "/talks",
+        json={
+            "event_id": 1,
+            "title": "Talk In Other Event",
+            "room": "Hall A",
+            "start": datetime.now(UTC).isoformat(),
+            "end": datetime.now(UTC).isoformat(),
+        },
+    )
+    assert res.status_code == 403
+    assert "User is not authorized to access this event" in res.json()["detail"]
+
+
+def test_post_talks_success_for_owning_organizer(mock_db):
+    event = models.Event(id=1, name="My Event", created_by_user_id=5)
+    # 1st query: Event check; 2nd query: Talk lookup (None => create)
+    mock_db.query.return_value.filter.return_value.first.side_effect = [event, None]
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.post(
+        "/talks",
+        json={
+            "event_id": 1,
+            "title": "Talk In My Event",
+            "room": "Hall A",
+            "start": datetime.now(UTC).isoformat(),
+            "end": datetime.now(UTC).isoformat(),
+        },
+    )
+    assert res.status_code == 201
+    assert res.json()["event_id"] == 1
+
+
+def test_write_endpoints_forbidden_for_user_role():
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, role="user", source="jwt"
+    )
+    res_rec = client.post("/talks/1/recordings", json={"source_path": "/tmp/rec.mp4"})
+    assert res_rec.status_code == 403
+    assert "Operation requires minimum role 'organizer'" in res_rec.json()["detail"]
+
+    res_app = client.post("/talks/1/approve")
+    assert res_app.status_code == 403
+    assert "Operation requires minimum role 'organizer'" in res_app.json()["detail"]
+
+
+def test_write_endpoints_forbidden_for_non_owning_organizer(mock_db):
+    event = models.Event(id=1, name="Event 1", created_by_user_id=99)
+    talk = models.Talk(
+        id=1,
+        event_id=1,
+        title="Test Talk",
+        room="Room 1",
+        start=datetime.now(UTC),
+        end=datetime.now(UTC),
+        status="waiting_for_files",
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [talk, event]
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.post("/talks/1/recordings", json={"source_path": "/tmp/rec.mp4"})
+    assert res.status_code == 403
+    assert "User is not authorized to access this event" in res.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Event Update & Delete Tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_event_forbidden_for_user_role():
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, role="user", source="jwt"
+    )
+    res = client.patch("/events/1", json={"name": "New Name"})
+    assert res.status_code == 403
+    assert "Operation requires minimum role 'organizer'" in res.json()["detail"]
+
+
+def test_update_event_forbidden_for_non_owning_organizer(mock_db):
+    event = models.Event(id=1, name="Old Name", created_by_user_id=10)
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.patch("/events/1", json={"name": "New Name"})
+    assert res.status_code == 403
+    assert "User is not authorized to access this event" in res.json()["detail"]
+
+
+def test_update_event_empty_name(mock_db):
+    event = models.Event(id=1, name="Old Name", created_by_user_id=5)
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.patch("/events/1", json={"name": "   "})
+    assert res.status_code == 400
+    assert "Event name cannot be empty" in res.json()["detail"]
+
+
+def test_update_event_success_for_owner(mock_db):
+    event = models.Event(id=1, name="Old Name", created_by_user_id=5)
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.patch("/events/1", json={"name": "Updated Summit 2026"})
+    assert res.status_code == 200
+    assert res.json()["name"] == "Updated Summit 2026"
+    assert event.name == "Updated Summit 2026"
+
+
+def test_update_event_success_for_admin(mock_db):
+    event = models.Event(id=1, name="Old Name", created_by_user_id=10)
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, role="admin", source="jwt"
+    )
+
+    res = client.patch("/events/1", json={"name": "Admin Renamed"})
+    assert res.status_code == 200
+    assert res.json()["name"] == "Admin Renamed"
+    assert event.name == "Admin Renamed"
+
+
+def test_delete_event_forbidden_for_non_owning_organizer(mock_db):
+    event = models.Event(id=1, name="Other Event", created_by_user_id=10, talks=[])
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    res = client.delete("/events/1")
+    assert res.status_code == 403
+    assert "User is not authorized to access this event" in res.json()["detail"]
+
+
+def test_delete_event_success_for_owner(mock_db):
+    talk = models.Talk(id=42, event_id=1, title="Sample Talk")
+    event = models.Event(id=1, name="My Event", created_by_user_id=5, talks=[talk])
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=5, role="organizer", source="jwt"
+    )
+
+    fake_storage = MagicMock()
+    app.dependency_overrides[get_storage_backend] = lambda: fake_storage
+
+    res = client.delete("/events/1")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok", "deleted_id": 1}
+    fake_storage.delete.assert_called_with("42")
+    mock_db.delete.assert_called_with(event)
+
+
+def test_delete_event_success_for_admin(mock_db):
+    event = models.Event(id=1, name="Any Event", created_by_user_id=99, talks=[])
+    mock_db.query.return_value.filter.return_value.first.return_value = event
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1, role="admin", source="jwt"
+    )
+
+    fake_storage = MagicMock()
+    app.dependency_overrides[get_storage_backend] = lambda: fake_storage
+
+    res = client.delete("/events/1")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok", "deleted_id": 1}
+    mock_db.delete.assert_called_with(event)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -41,6 +41,8 @@ def mock_db():
             obj.created_at = datetime.now(UTC)
 
     db.refresh.side_effect = fake_refresh
+    mock_filter = db.query.return_value.filter.return_value
+    mock_filter.with_for_update.return_value = mock_filter
     return db
 
 
@@ -548,6 +550,7 @@ def test_delete_event_success_for_owner(mock_db):
     res = client.delete("/events/1")
     assert res.status_code == 200
     assert res.json() == {"status": "ok", "deleted_id": 1}
+    assert mock_db.query.return_value.filter.return_value.with_for_update.called
     fake_storage.delete.assert_called_with("42")
     mock_db.delete.assert_called_with(event)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -255,12 +255,22 @@ def test_review_records_human_user_id(mock_db):
         end=datetime.now(UTC),
         status="preview",
     )
-    mock_db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = talk
+    event = models.Event(id=1, name="Keynote Event", created_by_user_id=42)
+
+    def mock_query(model):
+        m = MagicMock()
+        if model == models.Event:
+            m.filter.return_value.first.return_value = event
+        else:
+            m.filter.return_value.with_for_update.return_value.first.return_value = talk
+        return m
+
+    mock_db.query.side_effect = mock_query
 
     app.dependency_overrides[get_db] = lambda: mock_db
     app.dependency_overrides[get_storage_backend] = lambda: mock_storage
     app.dependency_overrides[get_current_user] = lambda: CurrentUser(
-        user_id=42, email="reviewer@example.com", role="user", source="jwt"
+        user_id=42, email="reviewer@example.com", role="organizer", source="jwt"
     )
 
     res = client.post("/talks/5/review", json={"decision": "approve", "note": "Great!"})

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -76,13 +76,13 @@ def preview_talk():
 
 
 def test_review_unauthorized():
-    """POST /talks/{id}/review without API key returns 401."""
+    """POST /talks/{id}/review without credentials returns 401."""
     response = client.post(
         "/talks/1/review",
         json={"decision": "approve"},
     )
     assert response.status_code == 401
-    assert response.json()["detail"] == "Missing API Key"
+    assert response.json()["detail"] == "Not authenticated"
 
 
 def test_review_invalid_decision_returns_422_without_db_query(mock_db):

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app import models, schemas
-from app.auth import get_client
+from app.auth import CurrentUser, get_client, get_current_user
 from app.db import get_db
 from app.main import app
 from app.review_handlers import (
@@ -862,3 +862,123 @@ def test_needs_work_subsequent_cut_overwrites_outputs():
     assert fake_storage.get("1/raw/video.mp4").read_bytes() == (
         b"original raw video bytes"
     )
+
+
+def test_review_human_user_role_forbidden(mock_db, preview_talk):
+    """POST /talks/{id}/review returns 403 if human caller has role 'user'."""
+    mock_db.query.return_value.filter.return_value.first.return_value = preview_talk
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=10, email="user@example.com", role="user", source="cookie", event_ids=[]
+    )
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    response = client.post(
+        "/talks/1/review",
+        json={"decision": "approve"},
+    )
+    assert response.status_code == 403
+    assert "Operation requires minimum role 'organizer'" in response.json()["detail"]
+
+
+def test_review_human_organizer_unowned_event_forbidden(mock_db, preview_talk):
+    """POST /talks/{id}/review returns 403 if organizer does not own the event."""
+    unowned_event = models.Event(id=1, name="Other Event", created_by_user_id=999)
+
+    def mock_query(model):
+        m = MagicMock()
+        if model == models.Event:
+            m.filter.return_value.first.return_value = unowned_event
+        else:
+            m.filter.return_value.first.return_value = preview_talk
+            m.filter.return_value.with_for_update.return_value = m.filter.return_value
+        return m
+
+    mock_db.query.side_effect = mock_query
+
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=10,
+        email="org@example.com",
+        role="organizer",
+        source="cookie",
+        event_ids=[],
+    )
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    response = client.post(
+        "/talks/1/review",
+        json={"decision": "approve"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "User is not authorized to access this event"
+
+
+def test_review_human_organizer_owned_event_success(
+    mock_db, preview_talk, fake_storage
+):
+    """POST /talks/{id}/review succeeds for organizer who owns the event."""
+    owned_event = models.Event(id=1, name="Owned Event", created_by_user_id=10)
+
+    def mock_query(model):
+        m = MagicMock()
+        if model == models.Event:
+            m.filter.return_value.first.return_value = owned_event
+        else:
+            m.filter.return_value.first.return_value = preview_talk
+            m.filter.return_value.with_for_update.return_value = m.filter.return_value
+        return m
+
+    mock_db.query.side_effect = mock_query
+
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=10,
+        email="org@example.com",
+        role="organizer",
+        source="cookie",
+        event_ids=[],
+    )
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_storage_backend] = lambda: fake_storage
+
+    response = client.post(
+        "/talks/1/review",
+        json={"decision": "approve"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["talk"]["status"] == "pending_intro_outro"
+    assert data["review"]["user_id"] == 10
+
+
+def test_review_human_admin_success(mock_db, preview_talk, fake_storage):
+    """POST /talks/{id}/review succeeds for admin even if event created by someone else."""
+    event = models.Event(id=1, name="Event", created_by_user_id=999)
+
+    def mock_query(model):
+        m = MagicMock()
+        if model == models.Event:
+            m.filter.return_value.first.return_value = event
+        else:
+            m.filter.return_value.first.return_value = preview_talk
+            m.filter.return_value.with_for_update.return_value = m.filter.return_value
+        return m
+
+    mock_db.query.side_effect = mock_query
+
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        user_id=1,
+        email="admin@example.com",
+        role="admin",
+        source="cookie",
+        event_ids=[],
+    )
+    app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[get_storage_backend] = lambda: fake_storage
+
+    response = client.post(
+        "/talks/1/review",
+        json={"decision": "approve"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["talk"]["status"] == "pending_intro_outro"
+    assert data["review"]["user_id"] == 1

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -214,6 +214,75 @@ def test_talk_studio_page(client: TestClient, db_session):
     assert "Room 101" in response.text
 
 
+def test_talk_studio_human_session_user_access(client: TestClient, db_session):
+    from app.security import create_session_token
+
+    org = models.User(
+        email=f"org_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hash",
+        role="organizer",
+    )
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+
+    event = models.Event(name=f"Event {uuid.uuid4().hex}", created_by_user_id=org.id)
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+
+    now = datetime.now(tz=UTC)
+    talk = models.Talk(
+        event_id=event.id,
+        title="Human Session Talk",
+        room="Main Hall",
+        start=now,
+        end=now + timedelta(minutes=45),
+        status="preview",
+    )
+    db_session.add(talk)
+    db_session.commit()
+    db_session.refresh(talk)
+
+    # 1. Organizer owning event can access talk via session cookie
+    token = create_session_token(org.id, org.role)
+    client.cookies.set("veditor_session", token)
+    res = client.get(f"/studio/talks/{talk.id}")
+    assert res.status_code == 200
+    assert "Human Session Talk" in res.text
+    assert "Main Hall" in res.text
+
+    # 2. Admin can access talk via session cookie even if created by someone else
+    admin = models.User(
+        email=f"admin_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hash",
+        role="admin",
+    )
+    db_session.add(admin)
+    db_session.commit()
+    db_session.refresh(admin)
+
+    admin_token = create_session_token(admin.id, admin.role)
+    client.cookies.set("veditor_session", admin_token)
+    res_admin = client.get(f"/studio/talks/{talk.id}")
+    assert res_admin.status_code == 200
+
+    # 3. Another user who does not own the event gets 404
+    other_org = models.User(
+        email=f"other_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hash",
+        role="organizer",
+    )
+    db_session.add(other_org)
+    db_session.commit()
+    db_session.refresh(other_org)
+
+    other_token = create_session_token(other_org.id, other_org.role)
+    client.cookies.set("veditor_session", other_token)
+    res_other = client.get(f"/studio/talks/{talk.id}")
+    assert res_other.status_code == 404
+
+
 def test_talk_studio_not_found(client: TestClient, db_session):
     event = models.Event(name=f"Event {uuid.uuid4().hex}")
     db_session.add(event)

--- a/tests/test_talks.py
+++ b/tests/test_talks.py
@@ -178,6 +178,7 @@ def test_post_talks_concurrent_race_handled():
 
     mock_db.query.return_value.filter.return_value.first.side_effect = [
         None,
+        None,
         existing_talk,
     ]
 

--- a/tests/test_talks.py
+++ b/tests/test_talks.py
@@ -67,8 +67,18 @@ def test_post_talks_create_success():
     app.dependency_overrides[get_client] = lambda: mock_client
     app.dependency_overrides[get_db] = lambda: mock_db
 
-    # Simulate talk does not exist
-    mock_db.query.return_value.filter.return_value.first.return_value = None
+    # Simulate talk does not exist while event exists
+    mock_event = models.Event(id=1, name="Keynote Event")
+
+    def mock_query(model):
+        m = MagicMock()
+        if model == models.Event:
+            m.filter.return_value.first.return_value = mock_event
+        else:
+            m.filter.return_value.first.return_value = None
+        return m
+
+    mock_db.query.side_effect = mock_query
 
     start_time = datetime(2026, 9, 1, 10, 0, tzinfo=UTC)
     end_time = datetime(2026, 9, 1, 11, 0, tzinfo=UTC)
@@ -176,38 +186,50 @@ def test_post_talks_concurrent_race_handled():
         status="waiting_for_files",
     )
 
-    mock_db.query.return_value.filter.return_value.first.side_effect = [
-        None,
-        None,
-        existing_talk,
-    ]
+    try:
+        mock_event = models.Event(id=1, name="Keynote Event")
+        mock_event_query = MagicMock()
+        mock_event_query.filter.return_value.first.return_value = mock_event
 
-    mock_db.commit.side_effect = [
-        IntegrityError("duplicate key", params=None, orig=Exception("uq")),
-        None,
-    ]
+        mock_talk_query = MagicMock()
+        mock_talk_query.filter.return_value.first.side_effect = [
+            None,
+            existing_talk,
+        ]
 
-    response = client.post(
-        "/talks",
-        json={
-            "event_id": 1,
-            "title": "Concurrent Talk",
-            "room": "Updated Concurrent Room",
-            "start": start_time.isoformat(),
-            "end": updated_end.isoformat(),
-        },
-        headers={"X-API-Key": "valid_key"},
-    )
+        def mock_query(model):
+            if model == models.Event:
+                return mock_event_query
+            return mock_talk_query
 
-    assert response.status_code == 200
-    data = response.json()
-    assert data["id"] == 20
-    assert data["room"] == "Updated Concurrent Room"
-    assert existing_talk.room == "Updated Concurrent Room"
-    assert existing_talk.end == updated_end
-    assert mock_db.rollback.called
+        mock_db.query.side_effect = mock_query
 
-    app.dependency_overrides.clear()
+        mock_db.commit.side_effect = [
+            IntegrityError("duplicate key", params=None, orig=Exception("uq")),
+            None,
+        ]
+
+        response = client.post(
+            "/talks",
+            json={
+                "event_id": 1,
+                "title": "Concurrent Talk",
+                "room": "Updated Concurrent Room",
+                "start": start_time.isoformat(),
+                "end": updated_end.isoformat(),
+            },
+            headers={"X-API-Key": "valid_key"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == 20
+        assert data["room"] == "Updated Concurrent Room"
+        assert existing_talk.room == "Updated Concurrent Room"
+        assert existing_talk.end == updated_end
+        assert mock_db.rollback.called
+    finally:
+        app.dependency_overrides.clear()
 
 
 def test_get_talk_unauthorized():

--- a/tests/test_ui_events.py
+++ b/tests/test_ui_events.py
@@ -1,0 +1,488 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from app import models
+from app.db import Base, engine, get_db
+from app.main import app
+from app.security import create_session_token, hash_password
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def db_session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(
+        bind=connection, join_transaction_mode="create_savepoint"
+    )
+    app.dependency_overrides[get_db] = lambda: session
+
+    try:
+        yield session
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+def create_user(db_session, email: str, role: str) -> models.User:
+    user = models.User(
+        email=email,
+        hashed_password=hash_password("testpass123"),
+        role=role,
+        is_active=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def authenticate_client(client: TestClient, user: models.User):
+    token = create_session_token(user.id, user.role)
+    client.cookies.set("veditor_session", token)
+
+
+def test_get_events_unauthenticated(client: TestClient):
+    response = client.get("/studio/events", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+def test_get_events_forbidden_for_user_role(client: TestClient, db_session):
+    user = create_user(db_session, "viewer@test.com", "user")
+    authenticate_client(client, user)
+
+    response = client.get("/studio/events")
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Operation requires minimum role 'organizer'"
+
+
+def test_get_events_organizer_empty(client: TestClient, db_session):
+    organizer = create_user(db_session, "organizer1@test.com", "organizer")
+    authenticate_client(client, organizer)
+
+    response = client.get("/studio/events")
+    assert response.status_code == 200
+    assert "Events" in response.text
+    assert "Events — VEditor" in response.text
+    assert "Create Event" in response.text
+    assert "No events found. Create your first event above." in response.text
+    assert 'action="/studio/events"' in response.text
+    assert 'name="name"' in response.text
+
+
+def test_get_events_organizer_isolation(client: TestClient, db_session):
+    org1 = create_user(db_session, "org1@test.com", "organizer")
+    org2 = create_user(db_session, "org2@test.com", "organizer")
+
+    event1 = models.Event(name="Org 1 Summit", created_by_user_id=org1.id)
+    event2 = models.Event(name="Org 2 Conference", created_by_user_id=org2.id)
+    db_session.add_all([event1, event2])
+    db_session.commit()
+
+    # Logged in as org1: should see event1 but NOT event2
+    authenticate_client(client, org1)
+    response = client.get("/studio/events")
+    assert response.status_code == 200
+    assert "Org 1 Summit" in response.text
+    assert "Org 2 Conference" not in response.text
+    assert f"/studio?event_id={event1.id}" in response.text
+    assert "View Talks" in response.text
+
+
+def test_get_events_admin_sees_all(client: TestClient, db_session):
+    admin = create_user(db_session, "admin@test.com", "admin")
+    org = create_user(db_session, "org_events@test.com", "organizer")
+
+    event1 = models.Event(name="Admin Event Alpha", created_by_user_id=admin.id)
+    event2 = models.Event(name="Org Event Beta", created_by_user_id=org.id)
+    db_session.add_all([event1, event2])
+    db_session.commit()
+
+    authenticate_client(client, admin)
+    response = client.get("/studio/events")
+    assert response.status_code == 200
+    assert "Admin Event Alpha" in response.text
+    assert "Org Event Beta" in response.text
+    assert "admin@test.com" in response.text
+    assert "org_events@test.com" in response.text
+
+
+def test_post_events_unauthenticated(client: TestClient):
+    response = client.post(
+        "/studio/events",
+        data={"name": "Unauthorized Conf"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    assert response.headers["location"] == "/login"
+
+
+def test_post_events_forbidden_for_user_role(client: TestClient, db_session):
+    user = create_user(db_session, "user_post@test.com", "user")
+    authenticate_client(client, user)
+
+    response = client.post("/studio/events", data={"name": "Forbidden Conf"})
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Operation requires minimum role 'organizer'"
+
+
+def test_post_events_empty_name(client: TestClient, db_session):
+    organizer = create_user(db_session, "org_empty@test.com", "organizer")
+    authenticate_client(client, organizer)
+
+    response = client.post("/studio/events", data={"name": "   "})
+    assert response.status_code == 400
+    assert "Event name is required." in response.text
+
+
+def test_post_events_success_organizer(client: TestClient, db_session):
+    organizer = create_user(db_session, "org_creator@test.com", "organizer")
+    authenticate_client(client, organizer)
+
+    response = client.post(
+        "/studio/events",
+        data={"name": "FOSSASIA Summit 2026"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+    event = (
+        db_session.query(models.Event)
+        .filter(models.Event.name == "FOSSASIA Summit 2026")
+        .first()
+    )
+    assert event is not None
+    assert event.created_by_user_id == organizer.id
+    assert response.headers["location"] == f"/studio?event_id={event.id}"
+
+
+def test_sidebar_nav_events_link_visibility(client: TestClient, db_session):
+    # 1. Unauthenticated: nav-events-link should not exist
+    resp_anon = client.get("/studio")
+    assert 'id="nav-events-link"' not in resp_anon.text
+
+    # 2. User role: nav-events-link should not exist
+    user = create_user(db_session, "regular_user@test.com", "user")
+    authenticate_client(client, user)
+    resp_user = client.get("/studio")
+    assert 'id="nav-events-link"' not in resp_user.text
+    assert 'id="btn-events-link"' not in resp_user.text
+
+    # 3. Organizer role: nav-events-link should exist
+    organizer = create_user(db_session, "nav_org@test.com", "organizer")
+    authenticate_client(client, organizer)
+    resp_org = client.get("/studio")
+    assert 'id="nav-events-link"' in resp_org.text
+    assert 'id="btn-events-link"' in resp_org.text
+
+    # When on /studio/events, nav link has active class
+    resp_events = client.get("/studio/events")
+    assert 'id="nav-events-link"' in resp_events.text
+    assert "nav-item active" in resp_events.text
+
+    # 4. Admin role: nav-events-link and btn-events-link exist
+    admin = create_user(db_session, "nav_admin@test.com", "admin")
+    authenticate_client(client, admin)
+    resp_admin = client.get("/studio")
+    assert 'id="nav-events-link"' in resp_admin.text
+    assert 'id="btn-events-link"' in resp_admin.text
+
+
+def test_dashboard_quick_talk_event_selection(client: TestClient, db_session):
+    org1 = create_user(db_session, "qt_org1@test.com", "organizer")
+    org2 = create_user(db_session, "qt_org2@test.com", "organizer")
+
+    # 1. Organizer with no events sees text input fallback
+    authenticate_client(client, org1)
+    resp_empty = client.get("/studio")
+    assert '<input type="text" id="quick-event-name"' in resp_empty.text
+
+    # 2. Add events for org1 and org2
+    event1 = models.Event(name="Org1 Selectable Summit", created_by_user_id=org1.id)
+    event2 = models.Event(name="Org2 Private Conference", created_by_user_id=org2.id)
+    db_session.add_all([event1, event2])
+    db_session.commit()
+
+    # 3. Org1 should see <select id="quick-event-name"> with event1, but NOT event2
+    resp_org1 = client.get("/studio")
+    assert '<select id="quick-event-name"' in resp_org1.text
+    assert "Org1 Selectable Summit" in resp_org1.text
+    assert "Org2 Private Conference" not in resp_org1.text
+
+    # 4. Admin should see both events in <select id="quick-event-name">
+    admin = create_user(db_session, "qt_admin@test.com", "admin")
+    authenticate_client(client, admin)
+    resp_admin = client.get("/studio")
+    assert '<select id="quick-event-name"' in resp_admin.text
+    assert "Org1 Selectable Summit" in resp_admin.text
+    assert "Org2 Private Conference" in resp_admin.text
+
+
+def test_events_page_renders_clickable_name_and_action_buttons(
+    client: TestClient, db_session
+):
+    org = create_user(db_session, "ui_actions_org@test.com", "organizer")
+    event = models.Event(name="Clickable Summit", created_by_user_id=org.id)
+    db_session.add(event)
+    db_session.commit()
+
+    authenticate_client(client, org)
+    response = client.get("/studio/events")
+    assert response.status_code == 200
+    # Clickable name linking to /studio?event_id={id}
+    assert f'href="/studio?event_id={event.id}"' in response.text
+    assert "event-title-link" in response.text
+    assert "Clickable Summit" in response.text
+    # Edit & Delete buttons
+    assert 'class="btn btn-ghost btn-sm btn-edit-event"' in response.text
+    assert (
+        'class="btn btn-ghost btn-sm btn-delete-event btn-danger-ghost"'
+        in response.text
+    )
+    assert f'data-event-id="{event.id}"' in response.text
+    # Edit Modal
+    assert 'id="modal-edit-event"' in response.text
+    assert 'id="edit-event-form"' in response.text
+    # Delete Modal
+    assert 'id="modal-delete-event"' in response.text
+    assert 'id="delete-event-form"' in response.text
+
+
+def test_post_events_edit_success_and_permissions(client: TestClient, db_session):
+    org1 = create_user(db_session, "edit_org1@test.com", "organizer")
+    org2 = create_user(db_session, "edit_org2@test.com", "organizer")
+    admin = create_user(db_session, "edit_admin@test.com", "admin")
+
+    event = models.Event(name="Original Name", created_by_user_id=org1.id)
+    db_session.add(event)
+    db_session.commit()
+
+    # 1. Unauthenticated
+    resp = client.post(
+        f"/studio/events/{event.id}/edit",
+        data={"name": "Hacked"},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 303)
+    assert resp.headers["location"] == "/login"
+
+    # 2. Non-owning organizer gets 403
+    authenticate_client(client, org2)
+    resp_org2 = client.post(
+        f"/studio/events/{event.id}/edit",
+        data={"name": "Org2 Rename"},
+    )
+    assert resp_org2.status_code == 403
+
+    # 3. Empty name gets 400
+    authenticate_client(client, org1)
+    resp_empty = client.post(
+        f"/studio/events/{event.id}/edit",
+        data={"name": "   "},
+    )
+    assert resp_empty.status_code == 400
+
+    # 4. Owning organizer succeeds
+    resp_owner = client.post(
+        f"/studio/events/{event.id}/edit",
+        data={"name": "Renamed By Owner"},
+        follow_redirects=False,
+    )
+    assert resp_owner.status_code == 303
+    assert resp_owner.headers["location"] == "/studio/events"
+    db_session.refresh(event)
+    assert event.name == "Renamed By Owner"
+
+    # 5. Admin can rename any event
+    authenticate_client(client, admin)
+    resp_admin = client.post(
+        f"/studio/events/{event.id}/edit",
+        data={"name": "Renamed By Admin"},
+        follow_redirects=False,
+    )
+    assert resp_admin.status_code == 303
+    db_session.refresh(event)
+    assert event.name == "Renamed By Admin"
+
+
+def test_post_events_delete_success_and_permissions(client: TestClient, db_session):
+    org1 = create_user(db_session, "del_org1@test.com", "organizer")
+    org2 = create_user(db_session, "del_org2@test.com", "organizer")
+    admin = create_user(db_session, "del_admin@test.com", "admin")
+
+    event1 = models.Event(name="Event To Delete 1", created_by_user_id=org1.id)
+    event2 = models.Event(name="Event To Delete 2", created_by_user_id=org1.id)
+    db_session.add_all([event1, event2])
+    db_session.commit()
+
+    # 1. Non-owning organizer gets 403
+    authenticate_client(client, org2)
+    resp_org2 = client.post(f"/studio/events/{event1.id}/delete")
+    assert resp_org2.status_code == 403
+
+    # 2. Owning organizer deletes event1
+    authenticate_client(client, org1)
+    resp_owner = client.post(
+        f"/studio/events/{event1.id}/delete",
+        follow_redirects=False,
+    )
+    assert resp_owner.status_code == 303
+    assert resp_owner.headers["location"] == "/studio/events"
+    assert (
+        db_session.query(models.Event).filter(models.Event.id == event1.id).first()
+        is None
+    )
+
+    # 3. Admin deletes event2
+    authenticate_client(client, admin)
+    resp_admin = client.post(
+        f"/studio/events/{event2.id}/delete",
+        follow_redirects=False,
+    )
+    assert resp_admin.status_code == 303
+    assert (
+        db_session.query(models.Event).filter(models.Event.id == event2.id).first()
+        is None
+    )
+
+
+def test_dashboard_talks_scoped_to_organizers_events(client: TestClient, db_session):
+    from datetime import UTC, datetime, timedelta
+
+    org1 = create_user(db_session, "scope_org1@test.com", "organizer")
+    org2 = create_user(db_session, "scope_org2@test.com", "organizer")
+    admin = create_user(db_session, "scope_admin@test.com", "admin")
+
+    event1 = models.Event(name="Summit Alpha", created_by_user_id=org1.id)
+    event2 = models.Event(name="Conf Beta", created_by_user_id=org2.id)
+    db_session.add_all([event1, event2])
+    db_session.commit()
+
+    now = datetime.now(tz=UTC)
+    talk1 = models.Talk(
+        event_id=event1.id,
+        title="Org1 Exclusive Talk Alpha",
+        room="Hall 1",
+        start=now,
+        end=now + timedelta(minutes=45),
+        status="waiting_for_files",
+    )
+    talk2 = models.Talk(
+        event_id=event2.id,
+        title="Org2 Exclusive Talk Beta",
+        room="Hall 2",
+        start=now,
+        end=now + timedelta(minutes=45),
+        status="waiting_for_files",
+    )
+    db_session.add_all([talk1, talk2])
+    db_session.commit()
+
+    # 1. Organizer 1 visits /studio: only sees Talk 1, NOT Talk 2
+    authenticate_client(client, org1)
+    resp_org1 = client.get("/studio")
+    assert "Org1 Exclusive Talk Alpha" in resp_org1.text
+    assert "Org2 Exclusive Talk Beta" not in resp_org1.text
+    # Check stats count is 1
+    assert "1 result" in resp_org1.text
+
+    # 2. Organizer 2 visits /studio: only sees Talk 2, NOT Talk 1
+    authenticate_client(client, org2)
+    resp_org2 = client.get("/studio")
+    assert "Org2 Exclusive Talk Beta" in resp_org2.text
+    assert "Org1 Exclusive Talk Alpha" not in resp_org2.text
+    assert "1 result" in resp_org2.text
+
+    # 3. Admin visits /studio: sees BOTH talks
+    authenticate_client(client, admin)
+    resp_admin = client.get("/studio")
+    assert "Org1 Exclusive Talk Alpha" in resp_admin.text
+    assert "Org2 Exclusive Talk Beta" in resp_admin.text
+
+    # 4. Organizer 1 filters by event2 (not owned): sees 0 talks
+    authenticate_client(client, org1)
+    resp_cross_filter = client.get(f"/studio?event_id={event2.id}")
+    assert "Org1 Exclusive Talk Alpha" not in resp_cross_filter.text
+    assert "Org2 Exclusive Talk Beta" not in resp_cross_filter.text
+    assert "0 results" in resp_cross_filter.text
+
+    # 5. Organizer 1 filters by event1 (owned): sees Talk 1
+    resp_own_filter = client.get(f"/studio?event_id={event1.id}")
+    assert "Org1 Exclusive Talk Alpha" in resp_own_filter.text
+    assert "1 result" in resp_own_filter.text
+
+
+def test_create_quick_talk_with_session_cookie(client: TestClient, db_session):
+    org = create_user(db_session, "quicktalk_org@test.com", "organizer")
+    event = models.Event(name="Quick Talk Conference", created_by_user_id=org.id)
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+
+    authenticate_client(client, org)
+
+    # Submit quick talk under this event
+    res = client.post(
+        "/talks/schedule/import",
+        json={
+            "event_id": event.id,
+            "event_name": event.name,
+            "title": "Modern Pipelines with PyAV",
+            "room": "Room 101",
+        },
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert data["event_id"] == event.id
+    assert data["imported_count"] == 1
+
+    # Verify talk exists in DB under event
+    talk = (
+        db_session.query(models.Talk)
+        .filter(
+            models.Talk.event_id == event.id,
+            models.Talk.title == "Modern Pipelines with PyAV",
+        )
+        .first()
+    )
+    assert talk is not None
+    assert talk.room == "Room 101"
+    assert talk.status == "waiting_for_files"
+
+
+def test_create_quick_talk_unauthorized_event(client: TestClient, db_session):
+    org1 = create_user(db_session, "org1_quicktalk@test.com", "organizer")
+    org2 = create_user(db_session, "org2_quicktalk@test.com", "organizer")
+    event2 = models.Event(name="Org2 Conf", created_by_user_id=org2.id)
+    db_session.add(event2)
+    db_session.commit()
+    db_session.refresh(event2)
+
+    # Org1 tries to create talk in Org2's event
+    authenticate_client(client, org1)
+    res = client.post(
+        "/talks/schedule/import",
+        json={
+            "event_id": event2.id,
+            "title": "Malicious Talk",
+            "room": "Room X",
+        },
+    )
+    assert res.status_code == 403

--- a/tests/test_ui_events.py
+++ b/tests/test_ui_events.py
@@ -362,6 +362,99 @@ def test_post_events_delete_success_and_permissions(client: TestClient, db_sessi
     )
 
 
+def test_delete_studio_event_teardown_and_failure_resilience(
+    client: TestClient, db_session
+):
+    from datetime import UTC, datetime, timedelta
+    from unittest.mock import MagicMock
+
+    from app.storage import get_storage_backend
+
+    org = create_user(db_session, "teardown_org@test.com", "organizer")
+    event = models.Event(name="Teardown Event", created_by_user_id=org.id)
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+
+    now = datetime.now(tz=UTC)
+    talk = models.Talk(
+        event_id=event.id,
+        title="Teardown Talk",
+        room="Room 1",
+        start=now,
+        end=now + timedelta(minutes=30),
+        status="preview",
+    )
+    db_session.add(talk)
+    db_session.commit()
+    db_session.refresh(talk)
+
+    job = models.Job(talk_id=talk.id, kind="transcode", status="queued")
+    review = models.Review(talk_id=talk.id, user_id=org.id, decision="approve")
+    db_session.add_all([job, review])
+    db_session.commit()
+
+    # 1. When storage fails, RuntimeError is propagated and event is NOT deleted
+    mock_storage = MagicMock()
+    mock_storage.delete.side_effect = RuntimeError("Storage disk unreachable")
+    app.dependency_overrides[get_storage_backend] = lambda: mock_storage
+
+    authenticate_client(client, org)
+    try:
+        with pytest.raises(RuntimeError, match="Cleanup failed"):
+            client.post(f"/studio/events/{event.id}/delete")
+
+        # Verify event, talk, job, and review still exist
+        assert (
+            db_session.query(models.Event).filter(models.Event.id == event.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Talk).filter(models.Talk.id == talk.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Job).filter(models.Job.id == job.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Review)
+            .filter(models.Review.id == review.id)
+            .first()
+            is not None
+        )
+    finally:
+        app.dependency_overrides.pop(get_storage_backend, None)
+
+    # 2. When storage succeeds, jobs/reviews/talk/event are deleted
+    mock_storage_ok = MagicMock()
+    app.dependency_overrides[get_storage_backend] = lambda: mock_storage_ok
+    try:
+        resp = client.post(f"/studio/events/{event.id}/delete", follow_redirects=False)
+        assert resp.status_code == 303
+        mock_storage_ok.delete.assert_called_once_with(str(talk.id))
+
+        assert (
+            db_session.query(models.Event).filter(models.Event.id == event.id).first()
+            is None
+        )
+        assert (
+            db_session.query(models.Talk).filter(models.Talk.id == talk.id).first()
+            is None
+        )
+        assert (
+            db_session.query(models.Job).filter(models.Job.id == job.id).first() is None
+        )
+        assert (
+            db_session.query(models.Review)
+            .filter(models.Review.id == review.id)
+            .first()
+            is None
+        )
+    finally:
+        app.dependency_overrides.pop(get_storage_backend, None)
+
+
 def test_dashboard_talks_scoped_to_organizers_events(client: TestClient, db_session):
     from datetime import UTC, datetime, timedelta
 

--- a/tests/test_ui_events.py
+++ b/tests/test_ui_events.py
@@ -455,6 +455,134 @@ def test_delete_studio_event_teardown_and_failure_resilience(
         app.dependency_overrides.pop(get_storage_backend, None)
 
 
+def test_delete_studio_event_multi_talk_failure_resilience_and_retry(
+    client: TestClient, db_session
+):
+    from datetime import UTC, datetime, timedelta
+    from unittest.mock import MagicMock
+
+    from app.storage import get_storage_backend
+
+    org = create_user(db_session, "multi_teardown_org@test.com", "organizer")
+    event = models.Event(name="Multi Teardown Event", created_by_user_id=org.id)
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+
+    now = datetime.now(tz=UTC)
+    talk1 = models.Talk(
+        event_id=event.id,
+        title="Teardown Talk 1",
+        room="Room 1",
+        start=now,
+        end=now + timedelta(minutes=30),
+        status="preview",
+    )
+    talk2 = models.Talk(
+        event_id=event.id,
+        title="Teardown Talk 2",
+        room="Room 2",
+        start=now + timedelta(hours=1),
+        end=now + timedelta(hours=1, minutes=30),
+        status="preview",
+    )
+    db_session.add_all([talk1, talk2])
+    db_session.commit()
+    db_session.refresh(talk1)
+    db_session.refresh(talk2)
+
+    job1 = models.Job(talk_id=talk1.id, kind="transcode", status="queued")
+    review1 = models.Review(talk_id=talk1.id, user_id=org.id, decision="approve")
+    job2 = models.Job(talk_id=talk2.id, kind="transcode", status="queued")
+    review2 = models.Review(talk_id=talk2.id, user_id=org.id, decision="approve")
+    db_session.add_all([job1, review1, job2, review2])
+    db_session.commit()
+
+    def mock_delete(key: str):
+        if key == str(talk1.id):
+            return
+        raise RuntimeError("Storage failure on talk 2")
+
+    mock_storage = MagicMock()
+    mock_storage.delete.side_effect = mock_delete
+    app.dependency_overrides[get_storage_backend] = lambda: mock_storage
+
+    authenticate_client(client, org)
+    try:
+        with pytest.raises(RuntimeError, match="Cleanup failed for talk"):
+            client.post(f"/studio/events/{event.id}/delete")
+
+        # Verify event, both talks, and their jobs/reviews remain untouched in DB
+        assert (
+            db_session.query(models.Event).filter(models.Event.id == event.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Talk).filter(models.Talk.id == talk1.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Talk).filter(models.Talk.id == talk2.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Job).filter(models.Job.id == job1.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Job).filter(models.Job.id == job2.id).first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Review)
+            .filter(models.Review.id == review1.id)
+            .first()
+            is not None
+        )
+        assert (
+            db_session.query(models.Review)
+            .filter(models.Review.id == review2.id)
+            .first()
+            is not None
+        )
+    finally:
+        app.dependency_overrides.pop(get_storage_backend, None)
+
+    # When storage succeeds on retry, all talks, jobs, reviews, and event are deleted
+    mock_storage_ok = MagicMock()
+    app.dependency_overrides[get_storage_backend] = lambda: mock_storage_ok
+    try:
+        resp = client.post(f"/studio/events/{event.id}/delete", follow_redirects=False)
+        assert resp.status_code == 303
+
+        assert (
+            db_session.query(models.Event).filter(models.Event.id == event.id).first()
+            is None
+        )
+        assert (
+            db_session.query(models.Talk).filter(models.Talk.id == talk1.id).first()
+            is None
+        )
+        assert (
+            db_session.query(models.Talk).filter(models.Talk.id == talk2.id).first()
+            is None
+        )
+        assert (
+            db_session.query(models.Job)
+            .filter(models.Job.id.in_([job1.id, job2.id]))
+            .count()
+            == 0
+        )
+        assert (
+            db_session.query(models.Review)
+            .filter(models.Review.id.in_([review1.id, review2.id]))
+            .count()
+            == 0
+        )
+    finally:
+        app.dependency_overrides.pop(get_storage_backend, None)
+
+
 def test_dashboard_talks_scoped_to_organizers_events(client: TestClient, db_session):
     from datetime import UTC, datetime, timedelta
 


### PR DESCRIPTION
## Closes #213 

>[!NOTE]
> - This is a stacked pr and will be ready for review after #220 is merged

Introduces full lifecycle event management capabilities for organizers and administrators, adds the Events Studio management UI with in-app edit and delete modals, makes event names clickable to navigate directly to their talks, and restricts the Studio dashboard so organizers only see talks and metrics for events they own. Additionally, applies role sufficiency and event access checks to all state-modifying talk and review endpoints.

---

### Key Features & Changes

#### 1. Event Lifecycle REST API (`app/routes/events.py`, `app/schemas.py`)
- **Event Creation (`POST /events`)**: Allows users with at least the `organizer` role to create new events, automatically attributing ownership via `created_by_user_id`.
- **Event Listing (`GET /events`)**: Returns events owned by the authenticated organizer, or all events if requested by an administrator.
- **Event Modification (`PATCH /events/{event_id}`)**: Enables organizers to update event metadata (such as `name`), validating non-empty names and enforcing ownership boundary checks.
- **Event Deletion (`DELETE /events/{event_id}`)**: Authorizes owners and admins to delete an event, cleans up underlying storage artifacts for all associated talks, and cascades database deletions across talks, jobs, and reviews.
- **Schemas (`app/schemas.py`)**: Added `EventUpdate` with retention overrides validation, and added `created_by_user_id` to `EventRead`.

#### 2. Studio Events Management UI (`app/routes/studio.py`, `app/ui/templates/events.html`)
- **Events Console (`GET /studio/events`)**: Server-side gated route that redirects unauthenticated users to `/login` and rejects standard users with HTTP 403. Renders owned events for organizers and all events with owner attribution for administrators.
- **Quick Event Creation (`POST /studio/events`)**: Web form handler to create events and redirect immediately to `/studio?event_id={id}`.
- **In-App Edit Modal (`POST /studio/events/{event_id}/edit`)**: Allows editing event names directly in the console through an in-app modal (`#modal-edit-event`).
- **In-App Delete Modal (`POST /studio/events/{event_id}/delete`)**: Replaced browser `window.confirm` dialogs with a styled, in-app confirmation modal (`#modal-delete-event`) displaying the event name before triggering cascading deletion.
- **Clickable Navigation**: Event names in the table link directly to `/studio?event_id={event.id}` to view and manage talks for that event.

#### 3. Organizer-Scoped Studio Dashboard (`app/routes/studio.py`, `app/ui/templates/dashboard.html`)
- **Dashboard Talk Scoping**: For logged-in organizers, talks displayed in the table, room filters, and summary metrics (`stats`: total, pending, processing, preview, published, broken) are strictly filtered to the organizer's owned events (`models.Talk.event_id.in_(org_event_ids)`).
- **Cross-Organizer Protection**: Attempting to filter by an `event_id` not owned by the organizer returns zero talks. Administrators retain visibility across all events.
- **Quick Talk Modal Event Selection**: Updated `#modal-quick-talk` to render a native `<select id="quick-event-name">` populated with the organizer's events, falling back to text input if no events exist.

#### 4. Authorization & Attribution on State Mutations (`app/routes/talks.py`, `app/routes/reviews.py`, `app/review_handlers.py`)
- Gated state-changing endpoints (`POST /talks`, `POST /talks/{id}/recordings`, `POST /talks/{id}/approve`) with `require_role("organizer")` and `check_event_access`.
- Attributed reviews to authenticated reviewers (`Review.user_id`) across review handlers (`handle_approve`, `handle_needs_work`, `handle_reject`).

---

### Architectural Invariants & Code Standards
- **Pure Pipeline Guard**: Maintained zero imports from FastAPI, RQ, SQLAlchemy, or DB models in `app/pipeline/`.
- **Storage Boundary Guard**: All file and directory deletions route strictly through `StorageBackend`.
- **Design System Rules**: All CSS classes are defined in dedicated stylesheets (`app/ui/static/css/events.css`) and script logic in `app/ui/static/js/events.js`, strictly adhering to the project's zero-inline-style and zero-inline-script AST test rules.

---

### Verification

#### Automated Tests
- `tests/test_events.py`: 28 passed (creation, listing, patch, delete, validation, owner/admin permissions, cross-organizer isolation).
- `tests/test_ui_events.py`: 15 passed (Studio events routing, edit modal, delete modal, clickable link navigation, dashboard talk scoping).
- `tests/test_studio.py`: 24 passed (including `test_templates_have_no_inline_css_or_js`).
- `tests/test_storage_boundary.py` & `tests/test_pipeline_imports.py`: 5 passed.
- **Full Test Suite**: All 538 tests passed (`uv run pytest --ignore=tests/test_smoke.py`).

## Summary by Sourcery

Introduce organizer-scoped event management across the API and Studio while strengthening authorization for event and talk workflows.

New Features:
- Add event lifecycle APIs and an organizer/admin Events Studio for creating, listing, editing, and deleting events.
- Provide clickable event navigation and event-aware quick talk creation in Studio.

Bug Fixes:
- Prevent organizers from viewing or modifying talks and reviews outside their owned events.
- Preserve machine-client event scoping while supporting authenticated human users across talk and Studio endpoints.

Enhancements:
- Scope organizer dashboards, filters, and metrics to owned events while retaining full administrator visibility.
- Record the human reviewer responsible for talk review decisions and expose event ownership in API responses.
- Use in-app event management modals and centralized event page styling and behavior.

Tests:
- Add comprehensive API, authorization, event-management UI, dashboard scoping, cleanup, and review attribution coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event management for organizers and admins, including creation, editing, listing, and deletion.
  - Added event ownership, role-based visibility, and event selection when creating talks.
  - Added review attribution to identify the user who made a decision.
  - Added event-filtered dashboard navigation and management controls.

- **Bug Fixes**
  - Improved authorization for events, talks, reviews, and studio content across user roles and API-key clients.
  - Improved session authentication and API-key handling.
  - Improved event deletion cleanup for related talks, jobs, reviews, and recordings.
  - Improved quick-talk validation, error messages, and keyboard interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->